### PR TITLE
Mejora dev local: polling del dashboard, PostCSS y favicon.

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,21 +18,8 @@ export const metadata: Metadata = {
     'Compra hoy, paga en tu ritmo. Ahorro, adelantos y liquidez con custodia Stellar vía Accesly.',
   generator: 'v0.app',
   icons: {
-    icon: [
-      {
-        url: '/icon-light-32x32.png',
-        media: '(prefers-color-scheme: light)',
-      },
-      {
-        url: '/icon-dark-32x32.png',
-        media: '(prefers-color-scheme: dark)',
-      },
-      {
-        url: '/icon.svg',
-        type: 'image/svg+xml',
-      },
-    ],
-    apple: '/apple-icon.png',
+    icon: [{ url: '/icon.svg', type: 'image/svg+xml' }],
+    apple: '/icon.svg',
   },
 }
 

--- a/lib/etherfuse/orders-api.ts
+++ b/lib/etherfuse/orders-api.ts
@@ -80,18 +80,24 @@ const CUSTOMER_ORDERS_PAGE_SIZE = 100;
 /**
  * Todas las páginas de órdenes del cliente (POST con paginación).
  * Si POST falla, hace fallback a GET (solo primera página).
+ * @param maxPages — por defecto {@link CUSTOMER_ORDERS_MAX_PAGES}; usar un valor bajo en rutas que solo necesitan un recorte reciente (p. ej. dashboard con polling).
  * @see https://docs.etherfuse.com/api-reference/customers/get-customer-orders-with-pagination
  */
 export async function fetchCustomerOrdersAllPages(
   customerId: string,
+  maxPages: number = CUSTOMER_ORDERS_MAX_PAGES,
 ): Promise<OrderRow[]> {
+  const pageLimit = Math.max(
+    1,
+    Math.min(CUSTOMER_ORDERS_MAX_PAGES, Math.floor(maxPages)),
+  );
   const path = `/ramp/customer/${encodeURIComponent(customerId)}/orders`;
   const collected: OrderRow[] = [];
   const seenIds = new Set<string>();
 
   for (
     let pageNumber = 0;
-    pageNumber < CUSTOMER_ORDERS_MAX_PAGES;
+    pageNumber < pageLimit;
     pageNumber++
   ) {
     const res = await etherfuseFetch(path, {

--- a/lib/seyf/dashboard-view-model.ts
+++ b/lib/seyf/dashboard-view-model.ts
@@ -49,6 +49,9 @@ function cetesFootnote(s: DashboardCetesSaldo): string | null {
   return null;
 }
 
+/** Con polling cada pocos segundos, no paginar decenas de miles de órdenes: basta para las últimas N del preview. */
+const DASHBOARD_ETHERFUSE_ORDER_PAGES = 2;
+
 /**
  * Ensambla números en vivo: saldo CETES×MXN (Etherfuse) y, en dev o con SEYF_ALLOW_MOCK_INVEST, ledger MVP.
  */
@@ -57,7 +60,10 @@ export async function buildDashboardViewModel(): Promise<DashboardViewModel> {
   const [cetesSaldo, investRuns, movementsAll] = await Promise.all([
     fetchDashboardCetesSaldo(ctx),
     investAllowed() ? listRuns(20) : Promise.resolve([] as InvestmentRun[]),
-    fetchUserMovements(ctx),
+    fetchUserMovements(ctx, {
+      etherfuseMaxPages: DASHBOARD_ETHERFUSE_ORDER_PAGES,
+      ledgerRunsLimit: 20,
+    }),
   ]);
 
   const ledgerPrincipal = ledgerPrincipalMxn(investRuns);

--- a/lib/seyf/user-movements.ts
+++ b/lib/seyf/user-movements.ts
@@ -178,22 +178,36 @@ function ledgerRunToMovement(r: InvestmentRun): UserMovement {
   };
 }
 
+export type FetchUserMovementsOptions = {
+  /** Límite de páginas Etherfuse (100 órdenes/página). Por defecto todas las permitidas; el dashboard usa pocas para no saturar con polling. */
+  etherfuseMaxPages?: number;
+  /** Límite de filas ledger; por defecto 80. */
+  ledgerRunsLimit?: number;
+};
+
 /**
  * Movimientos del usuario: ledger MVP (si aplica) + órdenes GET /ramp/customer/{id}/orders (Etherfuse FX API).
  */
 export async function fetchUserMovements(
   ctx: EtherfuseRampContext | null,
+  options?: FetchUserMovementsOptions,
 ): Promise<UserMovement[]> {
+  const ledgerLimit = options?.ledgerRunsLimit ?? 80;
+  const etherfusePages = options?.etherfuseMaxPages;
+
   const out: UserMovement[] = [];
 
   if (investAllowed()) {
-    const runs = await listRuns(80);
+    const runs = await listRuns(ledgerLimit);
     out.push(...runs.map(ledgerRunToMovement));
   }
 
   if (ctx && etherfuseRampAllowed()) {
     try {
-      const rows = await fetchCustomerOrdersAllPages(ctx.customerId);
+      const rows =
+        etherfusePages != null
+          ? await fetchCustomerOrdersAllPages(ctx.customerId, etherfusePages)
+          : await fetchCustomerOrdersAllPages(ctx.customerId);
       for (const row of rows) {
         if (row && typeof row === "object") {
           const m = etherfuseRowToMovement(row as Record<string, unknown>);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --webpack",
+    "dev:turbo": "next dev",
     "dev:webpack": "next dev --webpack",
     "build": "next build",
     "start": "next start",

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,7 +1,16 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Raíz fija del repo. Si `base` no se fija, el plugin usa `process.cwd()` y Next/Turbopack
+// a veces resuelve `@import 'tailwindcss'` desde `~/Documents`, falla en bucle y dispara CPU.
+const projectRoot = path.dirname(fileURLToPath(import.meta.url))
+
 /** @type {import('postcss-load-config').Config} */
 const config = {
   plugins: {
-    '@tailwindcss/postcss': {},
+    '@tailwindcss/postcss': {
+      base: projectRoot,
+    },
   },
 }
 

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="8" fill="#0a0a0a"/>
+  <path fill="#fafafa" d="M8 22V10h4.2l3.4 7.2L19 10h4.2v12h-2.9v-7l-2.8 5.5h-2.2L12.8 15v7H8z"/>
+</svg>


### PR DESCRIPTION
Limita páginas de órdenes Etherfuse al armar el view model del dashboard para no saturar CPU y red en cada poll. Añade opciones a fetchUserMovements y maxPages en fetchCustomerOrdersAllPages.

Fija base de @tailwindcss/postcss al directorio del proyecto para evitar resolución errónea de tailwindcss bajo ~/Documents. Cambia el script dev por defecto a next dev --webpack y deja dev:turbo para Turbopack.

Corrige metadatos de iconos: añade public/icon.svg y elimina rutas a PNG inexistentes.

Made-with: Cursor