### PR TITLE
feat: manejo global de errores API y UI (#37)

### DIFF
--- a/app/(app)/depositar/depositar-client.tsx
+++ b/app/(app)/depositar/depositar-client.tsx
@@ -7,6 +7,7 @@ import { AppBackLink } from '@/components/app/app-back-link'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { getSeyfErrorDisplayMessage } from '@/lib/seyf/read-client-api-error'
 
 const MIN_MXN = 500
 
@@ -70,7 +71,7 @@ export default function DepositarClient() {
       const data = (await res.json()) as { error?: string; walletMasked?: string; bankAccountId?: string }
       if (cancelled) return
       if (!res.ok) {
-        setAccountError(typeof data.error === 'string' ? data.error : 'No se pudo cargar la cuenta Etherfuse.')
+        setAccountError(getSeyfErrorDisplayMessage(data, 'No se pudo cargar la cuenta para depósito.'))
         setAccountPreview(null)
         return
       }
@@ -109,14 +110,8 @@ export default function DepositarClient() {
         })
         const data = (await res.json()) as MvpOnrampResponse
 
-        if (res.status === 403) {
-          setError(
-            'La rampa no está habilitada en producción (SEYF_ALLOW_ETHERFUSE_RAMP).',
-          )
-          return
-        }
         if (!res.ok) {
-          setError(typeof data.error === 'string' ? data.error : 'Error al generar depósito.')
+          setError(getSeyfErrorDisplayMessage(data, 'No se pudo generar la instrucción de depósito.'))
           return
         }
 

--- a/app/(app)/depositar/depositar-client.tsx
+++ b/app/(app)/depositar/depositar-client.tsx
@@ -7,7 +7,10 @@ import { AppBackLink } from '@/components/app/app-back-link'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { getSeyfErrorDisplayMessage } from '@/lib/seyf/read-client-api-error'
+import {
+  fetchWithSeyfRetryOnce,
+  getSeyfErrorDisplayMessage,
+} from '@/lib/seyf/read-client-api-error'
 
 const MIN_MXN = 500
 
@@ -67,7 +70,7 @@ export default function DepositarClient() {
   useEffect(() => {
     let cancelled = false
     ;(async () => {
-      const res = await fetch('/api/seyf/etherfuse/mvp/account')
+      const res = await fetchWithSeyfRetryOnce('/api/seyf/etherfuse/mvp/account')
       const data = (await res.json()) as { error?: string; walletMasked?: string; bankAccountId?: string }
       if (cancelled) return
       if (!res.ok) {
@@ -100,7 +103,7 @@ export default function DepositarClient() {
       setLoading(true)
       setDeposit(null)
       try {
-        const res = await fetch('/api/seyf/etherfuse/mvp/onramp', {
+        const res = await fetchWithSeyfRetryOnce('/api/seyf/etherfuse/mvp/onramp', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({

--- a/app/(app)/dev/etherfuse-offramp/etherfuse-offramp-dev-client.tsx
+++ b/app/(app)/dev/etherfuse-offramp/etherfuse-offramp-dev-client.tsx
@@ -1,7 +1,10 @@
 'use client'
 
 import { useCallback, useMemo, useState } from 'react'
-import { getSeyfErrorDisplayMessage } from '@/lib/seyf/read-client-api-error'
+import {
+  fetchWithSeyfRetryOnce,
+  getSeyfErrorDisplayMessage,
+} from '@/lib/seyf/read-client-api-error'
 import { AppBackLink } from '@/components/app/app-back-link'
 import { AppPageBody } from '@/components/app/app-page-body'
 import { OfframpActionCard } from '@/components/app/dev/offramp-action-card'
@@ -47,7 +50,7 @@ export default function EtherfuseOfframpDevClient() {
     }
     const t = sourceAssetOverride.trim()
     if (t) body.sourceAsset = t
-    const res = await fetch('/api/seyf/etherfuse/quote/offramp', {
+    const res = await fetchWithSeyfRetryOnce('/api/seyf/etherfuse/quote/offramp', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
@@ -75,7 +78,7 @@ export default function EtherfuseOfframpDevClient() {
       if (!quoteId) {
         throw new Error('No encuentro quoteId en la cotización (~2 min de validez)')
       }
-      const res = await fetch('/api/seyf/etherfuse/order/offramp', {
+      const res = await fetchWithSeyfRetryOnce('/api/seyf/etherfuse/order/offramp', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ quoteId, useAnchor }),
@@ -116,7 +119,7 @@ export default function EtherfuseOfframpDevClient() {
       for (let i = 0; i < 12; i++) {
         pollAttempts = i + 1
         if (i > 0) await new Promise((r) => setTimeout(r, 1500))
-        const gr = await fetch(
+        const gr = await fetchWithSeyfRetryOnce(
           `/api/seyf/etherfuse/prueba/order/${encodeURIComponent(orderId)}`,
         )
         if (!gr.ok) continue

--- a/app/(app)/dev/etherfuse-offramp/etherfuse-offramp-dev-client.tsx
+++ b/app/(app)/dev/etherfuse-offramp/etherfuse-offramp-dev-client.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useMemo, useState } from 'react'
+import { getSeyfErrorDisplayMessage } from '@/lib/seyf/read-client-api-error'
 import { AppBackLink } from '@/components/app/app-back-link'
 import { AppPageBody } from '@/components/app/app-page-body'
 import { OfframpActionCard } from '@/components/app/dev/offramp-action-card'
@@ -53,11 +54,7 @@ export default function EtherfuseOfframpDevClient() {
     })
     const data = await res.json().catch(() => ({}))
     if (!res.ok) {
-      const msg =
-        typeof data.error === 'string'
-          ? data.error
-          : `${res.status} ${res.statusText}${Object.keys(data).length ? ` — ${JSON.stringify(data)}` : ''}`
-      throw new Error(msg)
+      throw new Error(getSeyfErrorDisplayMessage(data, 'No se pudo obtener la cotización de retiro.'))
     }
     return JSON.stringify(data, null, 2)
   }, [sourceAmountTokens, sourceAssetOverride])
@@ -85,7 +82,7 @@ export default function EtherfuseOfframpDevClient() {
       })
       const data = await res.json().catch(() => ({}))
       if (!res.ok) {
-        throw new Error(typeof data.error === 'string' ? data.error : res.statusText)
+        throw new Error(getSeyfErrorDisplayMessage(data, 'No se pudo crear la orden de retiro.'))
       }
       return JSON.stringify(data, null, 2)
     },

--- a/app/(app)/dev/etherfuse-ramp/etherfuse-ramp-dev-client.tsx
+++ b/app/(app)/dev/etherfuse-ramp/etherfuse-ramp-dev-client.tsx
@@ -1,7 +1,10 @@
 'use client'
 
 import { useCallback, useMemo, useState } from 'react'
-import { getSeyfErrorDisplayMessage } from '@/lib/seyf/read-client-api-error'
+import {
+  fetchWithSeyfRetryOnce,
+  getSeyfErrorDisplayMessage,
+} from '@/lib/seyf/read-client-api-error'
 import { AppBackLink } from '@/components/app/app-back-link'
 import { AppPageBody } from '@/components/app/app-page-body'
 import { Button } from '@/components/ui/button'
@@ -47,7 +50,7 @@ export default function EtherfuseRampDevClient() {
     }
     const t = targetOverride.trim()
     if (t) body.targetAsset = t
-    const res = await fetch('/api/seyf/etherfuse/quote/onramp', {
+    const res = await fetchWithSeyfRetryOnce('/api/seyf/etherfuse/quote/onramp', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
@@ -74,7 +77,7 @@ export default function EtherfuseRampDevClient() {
     if (!quoteId) {
       throw new Error('No encuentro quoteId en la cotización (~2 min de validez)')
     }
-    const res = await fetch('/api/seyf/etherfuse/order/onramp', {
+    const res = await fetchWithSeyfRetryOnce('/api/seyf/etherfuse/order/onramp', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ quoteId }),
@@ -99,7 +102,7 @@ export default function EtherfuseRampDevClient() {
         'No encuentro orderId (revisa raíz o onramp/on_ramp en el JSON de la orden).',
       )
     }
-    const res = await fetch('/api/seyf/etherfuse/sandbox/fiat-received', {
+    const res = await fetchWithSeyfRetryOnce('/api/seyf/etherfuse/sandbox/fiat-received', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ orderId }),
@@ -114,7 +117,9 @@ export default function EtherfuseRampDevClient() {
     for (let i = 0; i < 12; i++) {
       pollAttempts = i + 1
       if (i > 0) await new Promise((r) => setTimeout(r, 1500))
-      const gr = await fetch(`/api/seyf/etherfuse/prueba/order/${encodeURIComponent(orderId)}`)
+      const gr = await fetchWithSeyfRetryOnce(
+        `/api/seyf/etherfuse/prueba/order/${encodeURIComponent(orderId)}`,
+      )
       if (!gr.ok) continue
       const gj = (await gr.json().catch(() => ({}))) as { order?: unknown }
       orderPolled = gj.order ?? null

--- a/app/(app)/dev/etherfuse-ramp/etherfuse-ramp-dev-client.tsx
+++ b/app/(app)/dev/etherfuse-ramp/etherfuse-ramp-dev-client.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useMemo, useState } from 'react'
+import { getSeyfErrorDisplayMessage } from '@/lib/seyf/read-client-api-error'
 import { AppBackLink } from '@/components/app/app-back-link'
 import { AppPageBody } from '@/components/app/app-page-body'
 import { Button } from '@/components/ui/button'
@@ -53,11 +54,7 @@ export default function EtherfuseRampDevClient() {
     })
     const data = await res.json().catch(() => ({}))
     if (!res.ok) {
-      const msg =
-        typeof data.error === 'string'
-          ? data.error
-          : `${res.status} ${res.statusText}${Object.keys(data).length ? ` — ${JSON.stringify(data)}` : ''}`
-      throw new Error(msg)
+      throw new Error(getSeyfErrorDisplayMessage(data, 'No se pudo obtener la cotización.'))
     }
     return JSON.stringify(data, null, 2)
   }, [sourceAmount, targetOverride])
@@ -84,7 +81,7 @@ export default function EtherfuseRampDevClient() {
     })
     const data = await res.json().catch(() => ({}))
     if (!res.ok) {
-      throw new Error(typeof data.error === 'string' ? data.error : res.statusText)
+      throw new Error(getSeyfErrorDisplayMessage(data, 'No se pudo crear la orden.'))
     }
     return JSON.stringify(data, null, 2)
   }, [])
@@ -109,7 +106,7 @@ export default function EtherfuseRampDevClient() {
     })
     const data = await res.json().catch(() => ({}))
     if (!res.ok) {
-      throw new Error(typeof data.error === 'string' ? data.error : res.statusText)
+      throw new Error(getSeyfErrorDisplayMessage(data, 'No se pudo simular el depósito SPEI en sandbox.'))
     }
 
     let orderPolled: unknown = null

--- a/app/(app)/dev/poc-omnibus/poc-omnibus-client.tsx
+++ b/app/(app)/dev/poc-omnibus/poc-omnibus-client.tsx
@@ -1,7 +1,10 @@
 'use client'
 
 import { useCallback, useEffect, useState } from 'react'
-import { getSeyfErrorDisplayMessage } from '@/lib/seyf/read-client-api-error'
+import {
+  fetchWithSeyfRetryOnce,
+  getSeyfErrorDisplayMessage,
+} from '@/lib/seyf/read-client-api-error'
 import Link from 'next/link'
 import { AppBackLink } from '@/components/app/app-back-link'
 import { AppPageBody } from '@/components/app/app-page-body'
@@ -31,7 +34,7 @@ export default function PocOmnibusClient() {
 
   const load = useCallback(async () => {
     setErr(null)
-    const res = await fetch('/api/seyf/poc/ledger')
+    const res = await fetchWithSeyfRetryOnce('/api/seyf/poc/ledger')
     const j = await res.json().catch(() => ({}))
     if (!res.ok) {
       setErr(getSeyfErrorDisplayMessage(j, 'No se pudo cargar el libro PoC.'))
@@ -53,7 +56,7 @@ export default function PocOmnibusClient() {
         setErr('Monto inválido')
         return
       }
-      const res = await fetch('/api/seyf/poc/ledger', {
+      const res = await fetchWithSeyfRetryOnce('/api/seyf/poc/ledger', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/app/(app)/dev/poc-omnibus/poc-omnibus-client.tsx
+++ b/app/(app)/dev/poc-omnibus/poc-omnibus-client.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useState } from 'react'
+import { getSeyfErrorDisplayMessage } from '@/lib/seyf/read-client-api-error'
 import Link from 'next/link'
 import { AppBackLink } from '@/components/app/app-back-link'
 import { AppPageBody } from '@/components/app/app-page-body'
@@ -33,7 +34,7 @@ export default function PocOmnibusClient() {
     const res = await fetch('/api/seyf/poc/ledger')
     const j = await res.json().catch(() => ({}))
     if (!res.ok) {
-      setErr(typeof j.error === 'string' ? j.error : res.statusText)
+      setErr(getSeyfErrorDisplayMessage(j, 'No se pudo cargar el libro PoC.'))
       return
     }
     setData(j as LedgerResponse)
@@ -63,7 +64,7 @@ export default function PocOmnibusClient() {
       })
       const j = await res.json().catch(() => ({}))
       if (!res.ok) {
-        setErr(typeof j.error === 'string' ? j.error : res.statusText)
+        setErr(getSeyfErrorDisplayMessage(j, 'No se pudo registrar el movimiento.'))
         return
       }
       setData({

--- a/app/(app)/error.tsx
+++ b/app/(app)/error.tsx
@@ -5,7 +5,7 @@ import { AppErrorFallback } from '@/components/errors/app-error-fallback'
 
 export default function AppSegmentError({
   error,
-  reset: _reset,
+  reset,
 }: {
   error: Error & { digest?: string }
   reset: () => void
@@ -18,6 +18,7 @@ export default function AppSegmentError({
     <AppErrorFallback
       title="No pudimos mostrar esta sección"
       description="No se pudo cargar esta sección. Vuelve al inicio o actualiza."
+      onRetry={reset}
     />
   )
 }

--- a/app/(app)/error.tsx
+++ b/app/(app)/error.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { useEffect } from 'react'
+import { AppErrorFallback } from '@/components/errors/app-error-fallback'
+
+export default function AppSegmentError({
+  error,
+  reset: _reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error('[app-segment-error]', error)
+  }, [error])
+
+  return (
+    <AppErrorFallback
+      title="No pudimos mostrar esta sección"
+      description="No se pudo cargar esta sección. Vuelve al inicio o actualiza."
+    />
+  )
+}

--- a/app/(app)/historial/historial-page-client.tsx
+++ b/app/(app)/historial/historial-page-client.tsx
@@ -13,6 +13,7 @@ import {
   HISTORIAL_POLL_MS,
 } from '@/lib/seyf/balance-poll-intervals'
 import { POLL_FETCH_INIT, pollBustUrl } from '@/lib/seyf/poll-fetch'
+import { fetchWithSeyfRetryOnce } from '@/lib/seyf/read-client-api-error'
 import type { UserMovement } from '@/lib/seyf/user-movements-types'
 import { formatMovementListSubtitle } from '@/lib/seyf/user-movements-types'
 import { cn } from '@/lib/utils'
@@ -85,7 +86,7 @@ export default function HistorialPageClient() {
     const errs: string[] = []
 
     try {
-      const stellarR = await fetch(
+      const stellarR = await fetchWithSeyfRetryOnce(
         `/api/seyf/stellar-movements?account=${encodeURIComponent(addr)}`,
       )
       if (stellarR.ok) {
@@ -100,7 +101,10 @@ export default function HistorialPageClient() {
     }
 
     try {
-      const umR = await fetch(pollBustUrl('/api/seyf/user-movements'), POLL_FETCH_INIT)
+      const umR = await fetchWithSeyfRetryOnce(
+        pollBustUrl('/api/seyf/user-movements'),
+        POLL_FETCH_INIT,
+      )
       if (umR.ok) {
         const j = (await umR.json()) as { movements?: UserMovement[] }
         if (Array.isArray(j.movements)) fromApi = j.movements
@@ -132,8 +136,8 @@ export default function HistorialPageClient() {
     try {
       const addr = wallet.stellarAddress.trim()
       const [stellarR, umR] = await Promise.all([
-        fetch(`/api/seyf/stellar-movements?account=${encodeURIComponent(addr)}`),
-        fetch(pollBustUrl('/api/seyf/user-movements'), POLL_FETCH_INIT),
+        fetchWithSeyfRetryOnce(`/api/seyf/stellar-movements?account=${encodeURIComponent(addr)}`),
+        fetchWithSeyfRetryOnce(pollBustUrl('/api/seyf/user-movements'), POLL_FETCH_INIT),
       ])
       let stellar: UserMovement[] = []
       if (stellarR.ok) {

--- a/app/(app)/prueba-mxn-cetes/prueba-mxn-cetes-client.tsx
+++ b/app/(app)/prueba-mxn-cetes/prueba-mxn-cetes-client.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { AppPageBody } from '@/components/app/app-page-body'
 import { AppBackLink } from '@/components/app/app-back-link'
 import { Button } from '@/components/ui/button'
+import { getSeyfErrorDisplayMessage } from '@/lib/seyf/read-client-api-error'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
@@ -40,9 +41,9 @@ export default function PruebaMxnCetesClient() {
 
   const pollOrder = useCallback(async (oid: string) => {
     const res = await fetch(`/api/seyf/etherfuse/prueba/order/${encodeURIComponent(oid)}`)
-    const data = (await res.json()) as { order?: unknown; error?: string }
+    const data = (await res.json().catch(() => ({}))) as Record<string, unknown>
     if (!res.ok) {
-      setPollError(typeof data.error === 'string' ? data.error : 'Error al leer orden')
+      setPollError(getSeyfErrorDisplayMessage(data, 'No se pudo leer el estado de la orden.'))
       return null
     }
     const o = data.order
@@ -92,9 +93,9 @@ export default function PruebaMxnCetesClient() {
           simulateFiat,
         }),
       })
-      const data = await res.json()
+      const data = await res.json().catch(() => ({}))
       if (!res.ok) {
-        setError(typeof data.error === 'string' ? data.error : 'Error')
+        setError(getSeyfErrorDisplayMessage(data, 'No se pudo ejecutar la prueba.'))
         return
       }
       setRunResult(data)

--- a/app/(app)/prueba-mxn-cetes/prueba-mxn-cetes-client.tsx
+++ b/app/(app)/prueba-mxn-cetes/prueba-mxn-cetes-client.tsx
@@ -5,7 +5,10 @@ import Link from 'next/link'
 import { AppPageBody } from '@/components/app/app-page-body'
 import { AppBackLink } from '@/components/app/app-back-link'
 import { Button } from '@/components/ui/button'
-import { getSeyfErrorDisplayMessage } from '@/lib/seyf/read-client-api-error'
+import {
+  fetchWithSeyfRetryOnce,
+  getSeyfErrorDisplayMessage,
+} from '@/lib/seyf/read-client-api-error'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
@@ -40,7 +43,9 @@ export default function PruebaMxnCetesClient() {
   const stopPoll = useRef(false)
 
   const pollOrder = useCallback(async (oid: string) => {
-    const res = await fetch(`/api/seyf/etherfuse/prueba/order/${encodeURIComponent(oid)}`)
+    const res = await fetchWithSeyfRetryOnce(
+      `/api/seyf/etherfuse/prueba/order/${encodeURIComponent(oid)}`,
+    )
     const data = (await res.json().catch(() => ({}))) as Record<string, unknown>
     if (!res.ok) {
       setPollError(getSeyfErrorDisplayMessage(data, 'No se pudo leer el estado de la orden.'))
@@ -85,7 +90,7 @@ export default function PruebaMxnCetesClient() {
 
     setLoading(true)
     try {
-      const res = await fetch('/api/seyf/etherfuse/prueba/mxn-cetes', {
+      const res = await fetchWithSeyfRetryOnce('/api/seyf/etherfuse/prueba/mxn-cetes', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/app/api/seyf/dashboard/route.ts
+++ b/app/api/seyf/dashboard/route.ts
@@ -1,12 +1,18 @@
 import { NextResponse } from 'next/server'
+import { seyfInternalError } from '@/lib/seyf/api-error'
 import { buildDashboardViewModel } from '@/lib/seyf/dashboard-view-model'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
 export async function GET() {
-  const vm = await buildDashboardViewModel()
-  return NextResponse.json(vm, {
-    headers: { 'Cache-Control': 'no-store, max-age=0' },
-  })
+  try {
+    const vm = await buildDashboardViewModel()
+    return NextResponse.json(vm, {
+      headers: { 'Cache-Control': 'no-store, max-age=0' },
+    })
+  } catch (e) {
+    console.error('[api/seyf/dashboard]', e)
+    return seyfInternalError()
+  }
 }

--- a/app/api/seyf/etherfuse/assets/route.ts
+++ b/app/api/seyf/etherfuse/assets/route.ts
@@ -1,5 +1,10 @@
 import { NextResponse } from "next/server";
 import { fetchRampableAssetsForWallet } from "@/lib/etherfuse/ramp-api";
+import {
+  SEYF_RAMP_UNAUTHORIZED_MESSAGE_ES,
+  seyfApiError,
+  seyfErrorFromUnknown,
+} from "@/lib/seyf/api-error";
 import { getEtherfuseRampContext } from "@/lib/seyf/etherfuse-ramp-context";
 import { guardEtherfuseRampRoutes } from "@/lib/seyf/etherfuse-ramp-guard";
 
@@ -13,13 +18,7 @@ export async function GET() {
 
   const ctx = await getEtherfuseRampContext();
   if (!ctx) {
-    return NextResponse.json(
-      {
-        error:
-          "Sin contexto rampa: cookie /identidad o (solo dev) ETHERFUSE_MVP_* en .env.local.",
-      },
-      { status: 401 },
-    );
+    return seyfApiError(401, "unauthorized", { message_es: SEYF_RAMP_UNAUTHORIZED_MESSAGE_ES });
   }
 
   try {
@@ -28,7 +27,6 @@ export async function GET() {
     });
     return NextResponse.json({ assets, contextSource: ctx.source });
   } catch (e) {
-    const message = e instanceof Error ? e.message : "Error al listar activos";
-    return NextResponse.json({ error: message }, { status: 502 });
+    return seyfErrorFromUnknown(e);
   }
 }

--- a/app/api/seyf/etherfuse/lookup/stablebonds/route.ts
+++ b/app/api/seyf/etherfuse/lookup/stablebonds/route.ts
@@ -1,10 +1,12 @@
 import { NextResponse } from "next/server";
+import { seyfErrorFromUnknown } from "@/lib/seyf/api-error";
 import {
   fetchEtherfuseStablebonds,
   pickCetesStablebond,
 } from "@/lib/etherfuse/stablebonds-lookup";
 
 export const revalidate = 300;
+export const dynamic = "force-dynamic";
 
 /**
  * GET /api/seyf/etherfuse/lookup/stablebonds
@@ -30,8 +32,7 @@ export async function GET(req: Request) {
 
     return NextResponse.json(data);
   } catch (e) {
-    const message = e instanceof Error ? e.message : "Error stablebonds";
-    console.error("[lookup/stablebonds]", message);
-    return NextResponse.json({ error: message }, { status: 502 });
+    console.error("[lookup/stablebonds]", e);
+    return seyfErrorFromUnknown(e);
   }
 }

--- a/app/api/seyf/etherfuse/mvp/account/route.ts
+++ b/app/api/seyf/etherfuse/mvp/account/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { resolveMvpPartnerRampIdentity } from "@/lib/etherfuse/partner-accounts";
+import { seyfErrorFromUnknown } from "@/lib/seyf/api-error";
 import { guardEtherfuseRampRoutes } from "@/lib/seyf/etherfuse-ramp-guard";
 
 function maskPk(pk: string) {
@@ -24,7 +25,6 @@ export async function GET() {
       customerId: id.customerId,
     });
   } catch (e) {
-    const message = e instanceof Error ? e.message : "Error";
-    return NextResponse.json({ error: message }, { status: 502 });
+    return seyfErrorFromUnknown(e);
   }
 }

--- a/app/api/seyf/etherfuse/mvp/onramp/route.ts
+++ b/app/api/seyf/etherfuse/mvp/onramp/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { executeMvpPartnerOnramp } from "@/lib/etherfuse/mvp-onramp";
+import {
+  seyfApiError,
+  seyfErrorFromUnknown,
+  SEYF_VALIDATION_MESSAGE_ES,
+} from "@/lib/seyf/api-error";
 import { guardEtherfuseRampRoutes } from "@/lib/seyf/etherfuse-ramp-guard";
 
 const bodySchema = z.object({
@@ -22,20 +27,19 @@ export async function POST(req: Request) {
   try {
     json = await req.json();
   } catch {
-    return NextResponse.json({ error: "JSON inválido" }, { status: 400 });
+    return seyfApiError(400, "bad_json");
   }
 
   const parsed = bodySchema.safeParse(json);
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+    return seyfApiError(400, "validation_error", { message_es: SEYF_VALIDATION_MESSAGE_ES });
   }
 
   const mxn = Number.parseFloat(parsed.data.sourceAmount.replace(",", "."));
   if (!Number.isFinite(mxn) || mxn < 500) {
-    return NextResponse.json(
-      { error: "Monto inválido o mínimo 500 MXN." },
-      { status: 400 },
-    );
+    return seyfApiError(400, "validation_error", {
+      message_es: "El monto no es válido o es menor al mínimo permitido (500 MXN).",
+    });
   }
 
   try {
@@ -46,7 +50,6 @@ export async function POST(req: Request) {
     });
     return NextResponse.json(result);
   } catch (e) {
-    const message = e instanceof Error ? e.message : "Error en onramp MVP";
-    return NextResponse.json({ error: message }, { status: 502 });
+    return seyfErrorFromUnknown(e);
   }
 }

--- a/app/api/seyf/etherfuse/order/offramp/route.ts
+++ b/app/api/seyf/etherfuse/order/offramp/route.ts
@@ -3,6 +3,12 @@ import { z } from "zod";
 import { extractOrderIdFromCreateOrderResponse } from "@/lib/etherfuse/order-create-response";
 import { resolveMvpPartnerCryptoWalletId } from "@/lib/etherfuse/partner-accounts";
 import { createMxOfframpOrder } from "@/lib/etherfuse/ramp-api";
+import {
+  SEYF_RAMP_UNAUTHORIZED_MESSAGE_ES,
+  seyfApiError,
+  seyfErrorFromUnknown,
+  SEYF_VALIDATION_MESSAGE_ES,
+} from "@/lib/seyf/api-error";
 import { getEtherfuseRampContext } from "@/lib/seyf/etherfuse-ramp-context";
 import { guardEtherfuseRampRoutes } from "@/lib/seyf/etherfuse-ramp-guard";
 
@@ -22,25 +28,19 @@ export async function POST(req: Request) {
 
   const ctx = await getEtherfuseRampContext();
   if (!ctx) {
-    return NextResponse.json(
-      {
-        error:
-          "Sin contexto rampa: cookie /identidad o (solo dev) ETHERFUSE_MVP_* en .env.local.",
-      },
-      { status: 401 },
-    );
+    return seyfApiError(401, "unauthorized", { message_es: SEYF_RAMP_UNAUTHORIZED_MESSAGE_ES });
   }
 
   let json: unknown;
   try {
     json = await req.json();
   } catch {
-    return NextResponse.json({ error: "JSON inválido" }, { status: 400 });
+    return seyfApiError(400, "bad_json");
   }
 
   const parsed = bodySchema.safeParse(json);
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+    return seyfApiError(400, "validation_error", { message_es: SEYF_VALIDATION_MESSAGE_ES });
   }
 
   try {
@@ -65,12 +65,16 @@ export async function POST(req: Request) {
       contextSource: ctx.source,
     });
   } catch (e) {
-    const message = e instanceof Error ? e.message : "Error al crear orden offramp";
+    const message = e instanceof Error ? e.message : "";
     const conflict =
       message.includes("409") || message.toLowerCase().includes("pending");
-    return NextResponse.json(
-      { error: message },
-      { status: conflict ? 409 : 502 },
-    );
+    if (conflict) {
+      return seyfApiError(409, "conflict", {
+        message_es:
+          "Ya hay una operación pendiente con estos datos. Espera un momento o revisa el estado en Etherfuse.",
+        retryable: false,
+      });
+    }
+    return seyfErrorFromUnknown(e);
   }
 }

--- a/app/api/seyf/etherfuse/order/onramp/route.ts
+++ b/app/api/seyf/etherfuse/order/onramp/route.ts
@@ -3,6 +3,12 @@ import { z } from "zod";
 import { extractOrderIdFromCreateOrderResponse } from "@/lib/etherfuse/order-create-response";
 import { resolveMvpPartnerCryptoWalletId } from "@/lib/etherfuse/partner-accounts";
 import { createMxOnrampOrder } from "@/lib/etherfuse/ramp-api";
+import {
+  SEYF_RAMP_UNAUTHORIZED_MESSAGE_ES,
+  seyfApiError,
+  seyfErrorFromUnknown,
+  SEYF_VALIDATION_MESSAGE_ES,
+} from "@/lib/seyf/api-error";
 import { getEtherfuseRampContext } from "@/lib/seyf/etherfuse-ramp-context";
 import { guardEtherfuseRampRoutes } from "@/lib/seyf/etherfuse-ramp-guard";
 
@@ -20,25 +26,19 @@ export async function POST(req: Request) {
 
   const ctx = await getEtherfuseRampContext();
   if (!ctx) {
-    return NextResponse.json(
-      {
-        error:
-          "Sin contexto rampa: cookie /identidad o (solo dev) ETHERFUSE_MVP_* en .env.local.",
-      },
-      { status: 401 },
-    );
+    return seyfApiError(401, "unauthorized", { message_es: SEYF_RAMP_UNAUTHORIZED_MESSAGE_ES });
   }
 
   let json: unknown;
   try {
     json = await req.json();
   } catch {
-    return NextResponse.json({ error: "JSON inválido" }, { status: 400 });
+    return seyfApiError(400, "bad_json");
   }
 
   const parsed = bodySchema.safeParse(json);
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+    return seyfApiError(400, "validation_error", { message_es: SEYF_VALIDATION_MESSAGE_ES });
   }
 
   try {
@@ -62,11 +62,16 @@ export async function POST(req: Request) {
       contextSource: ctx.source,
     });
   } catch (e) {
-    const message = e instanceof Error ? e.message : "Error al crear orden";
-    const conflict = message.includes("409") || message.toLowerCase().includes("pending");
-    return NextResponse.json(
-      { error: message },
-      { status: conflict ? 409 : 502 },
-    );
+    const message = e instanceof Error ? e.message : "";
+    const conflict =
+      message.includes("409") || message.toLowerCase().includes("pending");
+    if (conflict) {
+      return seyfApiError(409, "conflict", {
+        message_es:
+          "Ya hay una operación pendiente con estos datos. Espera un momento o cancela la anterior en Etherfuse.",
+        retryable: false,
+      });
+    }
+    return seyfErrorFromUnknown(e);
   }
 }

--- a/app/api/seyf/etherfuse/prueba/mxn-cetes/confirm/route.ts
+++ b/app/api/seyf/etherfuse/prueba/mxn-cetes/confirm/route.ts
@@ -5,6 +5,11 @@ import {
   fetchOrderDetailsWithRetry,
   pickOrderDisplayFields,
 } from "@/lib/etherfuse/orders-api";
+import {
+  seyfApiError,
+  seyfErrorFromUnknown,
+  SEYF_VALIDATION_MESSAGE_ES,
+} from "@/lib/seyf/api-error";
 import { isEtherfuseDevPanelEnabled } from "@/lib/seyf/etherfuse-dev-panel";
 import { guardEtherfuseRampRoutes } from "@/lib/seyf/etherfuse-ramp-guard";
 
@@ -20,19 +25,19 @@ export async function POST(req: Request) {
   if (denied) return denied;
 
   if (!isEtherfuseDevPanelEnabled()) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+    return seyfApiError(404, "not_found");
   }
 
   let json: unknown;
   try {
     json = await req.json();
   } catch {
-    return NextResponse.json({ error: "JSON inválido" }, { status: 400 });
+    return seyfApiError(400, "bad_json");
   }
 
   const parsed = bodySchema.safeParse(json);
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+    return seyfApiError(400, "validation_error", { message_es: SEYF_VALIDATION_MESSAGE_ES });
   }
 
   const { orderId } = parsed.data;
@@ -44,16 +49,20 @@ export async function POST(req: Request) {
       body: JSON.stringify({ orderId }),
     });
     const { json: simJson, text } = await etherfuseReadBody(fr);
+    if (!fr.ok) {
+      console.error("[mxn-cetes/confirm] fiat_received", fr.status, text.slice(0, 800));
+    }
     const simulateFiat = fr.ok
       ? { ok: true as const, result: simJson }
-      : { ok: false as const, status: fr.status, error: text.slice(0, 500) };
+      : { ok: false as const, status: fr.status };
 
     let orderSnapshot: unknown = null;
-    let orderFetchError: string | null = null;
+    let orderFetchFailed = false;
     try {
       orderSnapshot = await fetchOrderDetailsWithRetry(orderId);
     } catch (e) {
-      orderFetchError = e instanceof Error ? e.message : String(e);
+      orderFetchFailed = true;
+      console.warn("[mxn-cetes/confirm] order fetch", e);
     }
 
     const orderDisplay = orderSnapshot
@@ -64,12 +73,10 @@ export async function POST(req: Request) {
       simulateFiat,
       order: orderSnapshot,
       orderDisplay,
-      orderFetchError,
+      orderFetchFailed,
     });
   } catch (e) {
-    const message =
-      e instanceof Error ? e.message : "Error al confirmar onramp sandbox";
-    console.error("[mxn-cetes/confirm]", message);
-    return NextResponse.json({ error: message }, { status: 502 });
+    console.error("[mxn-cetes/confirm]", e);
+    return seyfErrorFromUnknown(e);
   }
 }

--- a/app/api/seyf/etherfuse/prueba/mxn-cetes/route.ts
+++ b/app/api/seyf/etherfuse/prueba/mxn-cetes/route.ts
@@ -14,6 +14,11 @@ import {
   type MvpPartnerRampIdentity,
   resolveMvpPartnerRampIdentity,
 } from "@/lib/etherfuse/partner-accounts";
+import {
+  seyfApiError,
+  seyfErrorFromUnknown,
+  SEYF_VALIDATION_MESSAGE_ES,
+} from "@/lib/seyf/api-error";
 import { getEtherfuseRampContext } from "@/lib/seyf/etherfuse-ramp-context";
 import { isEtherfuseDevPanelEnabled } from "@/lib/seyf/etherfuse-dev-panel";
 import { guardEtherfuseRampRoutes } from "@/lib/seyf/etherfuse-ramp-guard";
@@ -50,22 +55,21 @@ export async function POST(req: Request) {
   try {
     json = await req.json();
   } catch {
-    return NextResponse.json({ error: "JSON inválido" }, { status: 400 });
+    return seyfApiError(400, "bad_json");
   }
 
   const parsed = bodySchema.safeParse(json);
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+    return seyfApiError(400, "validation_error", { message_es: SEYF_VALIDATION_MESSAGE_ES });
   }
 
   const mxn = Number.parseFloat(
     parsed.data.sourceAmount.replace(",", "."),
   );
   if (!Number.isFinite(mxn) || mxn < 500) {
-    return NextResponse.json(
-      { error: "Monto inválido o mínimo 500 MXN." },
-      { status: 400 },
-    );
+    return seyfApiError(400, "validation_error", {
+      message_es: "El monto no es válido o es menor al mínimo permitido (500 MXN).",
+    });
   }
 
   try {
@@ -91,12 +95,8 @@ export async function POST(req: Request) {
         }
       }
     } catch (e) {
-      const message =
-        e instanceof Error ? e.message : "No se pudo resolver identidad rampa";
-      return NextResponse.json(
-        { error: message, step: "identity" as const },
-        { status: 502 },
-      );
+      console.error("[mxn-cetes] identity", e);
+      return seyfErrorFromUnknown(e);
     }
 
     let assets: Awaited<
@@ -108,12 +108,8 @@ export async function POST(req: Request) {
       });
       assets = row.assets;
     } catch (e) {
-      const message =
-        e instanceof Error ? e.message : "Error en GET /ramp/assets";
-      return NextResponse.json(
-        { error: message, step: "ramp_assets" as const },
-        { status: 502 },
-      );
+      console.error("[mxn-cetes] ramp_assets", e);
+      return seyfErrorFromUnknown(e);
     }
     let cetesId = pickCetesTargetIdentifier(assets);
     if (!cetesId) {
@@ -124,13 +120,10 @@ export async function POST(req: Request) {
       }
     }
     if (!cetesId) {
-      return NextResponse.json(
-        {
-          error:
-            "No hay CETES usable: hace falta fila CETES en GET /ramp/assets (trust line en Stellar testnet al issuer que devuelve Etherfuse). No uses un issuer distinto en .env: en sandbox provoca NonStableAsset.",
-        },
-        { status: 422 },
-      );
+      return seyfApiError(422, "validation_error", {
+        message_es:
+          "No hay un activo CETES disponible para esta cuenta en sandbox. Revisa la línea de confianza en Stellar y la configuración de activos rampables.",
+      });
     }
 
     let ramp: Awaited<ReturnType<typeof executeMvpPartnerOnramp>>;
@@ -143,12 +136,8 @@ export async function POST(req: Request) {
         identity,
       });
     } catch (e) {
-      const message =
-        e instanceof Error ? e.message : "Error en cotización u orden onramp";
-      return NextResponse.json(
-        { error: message, step: "quote_or_order" as const },
-        { status: 502 },
-      );
+      console.error("[mxn-cetes] quote_or_order", e);
+      return seyfErrorFromUnknown(e);
     }
 
     const speiRecipientDisplayName =
@@ -167,17 +156,21 @@ export async function POST(req: Request) {
         body: JSON.stringify({ orderId: ramp.deposit.orderId }),
       });
       const { json: simJson, text } = await etherfuseReadBody(fr);
+      if (!fr.ok) {
+        console.error("[mxn-cetes] fiat_received", fr.status, text.slice(0, 800));
+      }
       simulateFiat = fr.ok
         ? { ok: true as const, result: simJson }
-        : { ok: false as const, status: fr.status, error: text.slice(0, 500) };
+        : { ok: false as const, status: fr.status };
     }
 
     let orderSnapshot: unknown = null;
-    let orderFetchError: string | null = null;
+    let orderFetchFailed = false;
     try {
       orderSnapshot = await fetchOrderDetailsWithRetry(ramp.deposit.orderId);
     } catch (e) {
-      orderFetchError = e instanceof Error ? e.message : String(e);
+      orderFetchFailed = true;
+      console.warn("[mxn-cetes] order fetch", e);
     }
 
     const orderDisplay = orderSnapshot
@@ -193,16 +186,12 @@ export async function POST(req: Request) {
       order: orderSnapshot,
       /** Resumen para UI: hash on-chain (`confirmedTxSignature`), estado y página Etherfuse (`statusPage`). */
       orderDisplay,
-      orderFetchError,
+      orderFetchFailed,
       speiRecipientDisplayName,
       prepareOnly,
     });
   } catch (e) {
-    const message = e instanceof Error ? e.message : "Error en prueba MXN→CETES";
-    console.error("[mxn-cetes]", message);
-    return NextResponse.json(
-      { error: message, step: "unknown" as const },
-      { status: 502 },
-    );
+    console.error("[mxn-cetes]", e);
+    return seyfErrorFromUnknown(e);
   }
 }

--- a/app/api/seyf/etherfuse/prueba/order/[orderId]/route.ts
+++ b/app/api/seyf/etherfuse/prueba/order/[orderId]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { fetchOrderDetails } from "@/lib/etherfuse/orders-api";
+import { seyfApiError, seyfErrorFromUnknown } from "@/lib/seyf/api-error";
 import { guardEtherfuseRampRoutes } from "@/lib/seyf/etherfuse-ramp-guard";
 
 /**
@@ -15,14 +16,15 @@ export async function GET(
 
   const { orderId } = await ctx.params;
   if (!orderId || !/^[0-9a-f-]{36}$/i.test(orderId)) {
-    return NextResponse.json({ error: "orderId inválido" }, { status: 400 });
+    return seyfApiError(400, "validation_error", {
+      message_es: "El identificador de orden no es válido.",
+    });
   }
 
   try {
     const order = await fetchOrderDetails(orderId);
     return NextResponse.json({ order });
   } catch (e) {
-    const message = e instanceof Error ? e.message : "Error";
-    return NextResponse.json({ error: message }, { status: 502 });
+    return seyfErrorFromUnknown(e);
   }
 }

--- a/app/api/seyf/etherfuse/quote/offramp/route.ts
+++ b/app/api/seyf/etherfuse/quote/offramp/route.ts
@@ -5,6 +5,12 @@ import {
   fetchRampableAssetsForWallet,
   pickOfframpSourceIdentifier,
 } from "@/lib/etherfuse/ramp-api";
+import {
+  SEYF_RAMP_UNAUTHORIZED_MESSAGE_ES,
+  seyfApiError,
+  seyfErrorFromUnknown,
+  SEYF_VALIDATION_MESSAGE_ES,
+} from "@/lib/seyf/api-error";
 import { getEtherfuseRampContext } from "@/lib/seyf/etherfuse-ramp-context";
 import { guardEtherfuseRampRoutes } from "@/lib/seyf/etherfuse-ramp-guard";
 
@@ -24,25 +30,19 @@ export async function POST(req: Request) {
 
   const ctx = await getEtherfuseRampContext();
   if (!ctx) {
-    return NextResponse.json(
-      {
-        error:
-          "Sin contexto rampa: cookie /identidad o (solo dev) variables ETHERFUSE_MVP_* en .env.local.",
-      },
-      { status: 401 },
-    );
+    return seyfApiError(401, "unauthorized", { message_es: SEYF_RAMP_UNAUTHORIZED_MESSAGE_ES });
   }
 
   let json: unknown;
   try {
     json = await req.json();
   } catch {
-    return NextResponse.json({ error: "JSON inválido" }, { status: 400 });
+    return seyfApiError(400, "bad_json");
   }
 
   const parsed = bodySchema.safeParse(json);
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+    return seyfApiError(400, "validation_error", { message_es: SEYF_VALIDATION_MESSAGE_ES });
   }
 
   try {
@@ -54,13 +54,10 @@ export async function POST(req: Request) {
       parsed.data.sourceAsset ?? null,
     );
     if (!source) {
-      return NextResponse.json(
-        {
-          error:
-            "No hay activo origen. Define ETHERFUSE_OFFRAMP_SOURCE_ASSET (CODE:ISSUER) o pasa sourceAsset en el body.",
-        },
-        { status: 422 },
-      );
+      return seyfApiError(422, "validation_error", {
+        message_es:
+          "No hay un activo origen configurado para esta cotización. Revisa la configuración o elige otro activo.",
+      });
     }
 
     const quote = await createMxOfframpQuote({
@@ -74,8 +71,7 @@ export async function POST(req: Request) {
       contextSource: ctx.source,
     });
   } catch (e) {
-    const message = e instanceof Error ? e.message : "Error al cotizar offramp";
-    console.error("[quote/offramp]", message);
-    return NextResponse.json({ error: message }, { status: 502 });
+    console.error("[quote/offramp]", e);
+    return seyfErrorFromUnknown(e);
   }
 }

--- a/app/api/seyf/etherfuse/quote/onramp/route.ts
+++ b/app/api/seyf/etherfuse/quote/onramp/route.ts
@@ -5,6 +5,12 @@ import {
   fetchRampableAssetsForWallet,
   pickOnrampTargetIdentifier,
 } from "@/lib/etherfuse/ramp-api";
+import {
+  SEYF_RAMP_UNAUTHORIZED_MESSAGE_ES,
+  seyfApiError,
+  seyfErrorFromUnknown,
+  SEYF_VALIDATION_MESSAGE_ES,
+} from "@/lib/seyf/api-error";
 import { getEtherfuseRampContext } from "@/lib/seyf/etherfuse-ramp-context";
 import { guardEtherfuseRampRoutes } from "@/lib/seyf/etherfuse-ramp-guard";
 
@@ -23,25 +29,19 @@ export async function POST(req: Request) {
 
   const ctx = await getEtherfuseRampContext();
   if (!ctx) {
-    return NextResponse.json(
-      {
-        error:
-          "Sin contexto rampa: cookie /identidad o (solo dev) variables ETHERFUSE_MVP_* en .env.local.",
-      },
-      { status: 401 },
-    );
+    return seyfApiError(401, "unauthorized", { message_es: SEYF_RAMP_UNAUTHORIZED_MESSAGE_ES });
   }
 
   let json: unknown;
   try {
     json = await req.json();
   } catch {
-    return NextResponse.json({ error: "JSON inválido" }, { status: 400 });
+    return seyfApiError(400, "bad_json");
   }
 
   const parsed = bodySchema.safeParse(json);
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+    return seyfApiError(400, "validation_error", { message_es: SEYF_VALIDATION_MESSAGE_ES });
   }
 
   try {
@@ -53,13 +53,10 @@ export async function POST(req: Request) {
       parsed.data.targetAsset ?? null,
     );
     if (!target) {
-      return NextResponse.json(
-        {
-          error:
-            "No hay activo destino. Define ETHERFUSE_ONRAMP_TARGET_ASSET (CODE:ISSUER) o pasa targetAsset en el body.",
-        },
-        { status: 422 },
-      );
+      return seyfApiError(422, "validation_error", {
+        message_es:
+          "No hay un activo destino configurado para esta cotización. Revisa la configuración o elige otro activo.",
+      });
     }
 
     const quote = await createMxOnrampQuote({
@@ -73,8 +70,7 @@ export async function POST(req: Request) {
       contextSource: ctx.source,
     });
   } catch (e) {
-    const message = e instanceof Error ? e.message : "Error al cotizar";
-    console.error("[quote/onramp]", message);
-    return NextResponse.json({ error: message }, { status: 502 });
+    console.error("[quote/onramp]", e);
+    return seyfErrorFromUnknown(e);
   }
 }

--- a/app/api/seyf/etherfuse/ramp-context/route.ts
+++ b/app/api/seyf/etherfuse/ramp-context/route.ts
@@ -1,5 +1,9 @@
 import { NextResponse } from "next/server";
 import { resolveMvpPartnerCryptoWalletId } from "@/lib/etherfuse/partner-accounts";
+import {
+  SEYF_RAMP_UNAUTHORIZED_MESSAGE_ES,
+  seyfApiError,
+} from "@/lib/seyf/api-error";
 import { getEtherfuseRampContext } from "@/lib/seyf/etherfuse-ramp-context";
 import { guardEtherfuseRampRoutes } from "@/lib/seyf/etherfuse-ramp-guard";
 
@@ -14,21 +18,18 @@ export async function GET() {
 
   const ctx = await getEtherfuseRampContext();
   if (!ctx) {
-    return NextResponse.json(
-      {
-        error:
-          "Sin contexto rampa: cookie /identidad o (solo dev) ETHERFUSE_MVP_* en .env.local.",
-      },
-      { status: 401 },
-    );
+    return seyfApiError(401, "unauthorized", { message_es: SEYF_RAMP_UNAUTHORIZED_MESSAGE_ES });
   }
 
   let cryptoWalletId: string | null = null;
-  let cryptoWalletError: string | null = null;
+  let cryptoWalletResolveFailed = false;
   try {
     cryptoWalletId = await resolveMvpPartnerCryptoWalletId(ctx.publicKey);
   } catch (e) {
-    cryptoWalletError = e instanceof Error ? e.message : String(e);
+    cryptoWalletResolveFailed = true;
+    if (process.env.NODE_ENV !== "production") {
+      console.warn("[ramp-context] cryptoWalletId resolve failed", e);
+    }
   }
 
   return NextResponse.json({
@@ -38,6 +39,6 @@ export async function GET() {
     source: ctx.source,
     cryptoWalletId,
     cryptoWalletResolved: Boolean(cryptoWalletId),
-    cryptoWalletError,
+    cryptoWalletResolveFailed,
   });
 }

--- a/app/api/seyf/etherfuse/sandbox/fiat-received/route.ts
+++ b/app/api/seyf/etherfuse/sandbox/fiat-received/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { etherfuseFetch, etherfuseReadBody } from '@/lib/etherfuse/client'
+import {
+  seyfApiError,
+  SEYF_VALIDATION_MESSAGE_ES,
+} from '@/lib/seyf/api-error'
 import { isEtherfuseDevPanelEnabled } from '@/lib/seyf/etherfuse-dev-panel'
 
 const bodySchema = z.object({
@@ -14,19 +18,19 @@ const bodySchema = z.object({
  */
 export async function POST(req: Request) {
   if (!isEtherfuseDevPanelEnabled()) {
-    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+    return seyfApiError(404, 'not_found')
   }
 
   let json: unknown
   try {
     json = await req.json()
   } catch {
-    return NextResponse.json({ error: 'JSON inválido' }, { status: 400 })
+    return seyfApiError(400, 'bad_json')
   }
 
   const parsed = bodySchema.safeParse(json)
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+    return seyfApiError(400, 'validation_error', { message_es: SEYF_VALIDATION_MESSAGE_ES })
   }
 
   const res = await etherfuseFetch('/ramp/order/fiat_received', {
@@ -36,11 +40,13 @@ export async function POST(req: Request) {
   })
   const { json: out, text } = await etherfuseReadBody(res)
   if (!res.ok) {
-    const msg = text.slice(0, 500)
-    return NextResponse.json(
-      { error: msg, detail: out },
-      { status: res.status >= 400 && res.status < 600 ? res.status : 502 },
-    )
+    console.error('[sandbox/fiat-received]', res.status, text.slice(0, 800), out)
+    const st = res.status >= 400 && res.status < 600 ? res.status : 502
+    if (st === 404) return seyfApiError(404, 'not_found')
+    if (st >= 500) {
+      return seyfApiError(502, 'provider_unavailable', { retryable: true })
+    }
+    return seyfApiError(400, 'validation_error', { message_es: SEYF_VALIDATION_MESSAGE_ES })
   }
   return NextResponse.json({ ok: true as const, result: out })
 }

--- a/app/api/seyf/invest/route.ts
+++ b/app/api/seyf/invest/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
+import { seyfApiError, SEYF_VALIDATION_MESSAGE_ES } from '@/lib/seyf/api-error'
 import { runMockAutoInvest } from '@/lib/seyf/investment-mvp'
 
 const bodySchema = z.object({
@@ -15,22 +16,21 @@ const bodySchema = z.object({
  */
 export async function POST(req: Request) {
   if (process.env.NODE_ENV === 'production' && process.env.SEYF_ALLOW_MOCK_INVEST !== 'true') {
-    return NextResponse.json(
-      { error: 'Mock invest disabled in production. Set SEYF_ALLOW_MOCK_INVEST=true or use real pipeline.' },
-      { status: 403 },
-    )
+    return seyfApiError(403, 'forbidden', {
+      message_es: 'Esta simulación de inversión no está habilitada en producción.',
+    })
   }
 
   let json: unknown
   try {
     json = await req.json()
   } catch {
-    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+    return seyfApiError(400, 'bad_json')
   }
 
   const parsed = bodySchema.safeParse(json)
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
+    return seyfApiError(400, 'validation_error', { message_es: SEYF_VALIDATION_MESSAGE_ES })
   }
 
   const run = await runMockAutoInvest(parsed.data)

--- a/app/api/seyf/invest/summary/route.ts
+++ b/app/api/seyf/invest/summary/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { seyfApiError, seyfInternalError } from '@/lib/seyf/api-error'
 import { getLedgerMeta, listRuns } from '@/lib/seyf/investment-mvp'
 
 /**
@@ -7,20 +8,26 @@ import { getLedgerMeta, listRuns } from '@/lib/seyf/investment-mvp'
  */
 export async function GET() {
   if (process.env.NODE_ENV === 'production' && process.env.SEYF_ALLOW_MOCK_INVEST !== 'true') {
-    return NextResponse.json(
-      { error: 'Mock invest disabled in production.' },
-      { status: 403 },
-    )
+    return seyfApiError(403, 'forbidden', {
+      message_es: 'El resumen de inversión simulada no está disponible en producción.',
+    })
   }
 
-  const [meta, runs] = await Promise.all([getLedgerMeta(), listRuns(20)])
-  const principalMxn = runs.filter((r) => r.status === 'completed').reduce((s, r) => s + r.amountMxn, 0)
-  const lastRate = runs[0]?.rateSnapshotAnnualPercent ?? null
+  try {
+    const [meta, runs] = await Promise.all([getLedgerMeta(), listRuns(20)])
+    const principalMxn = runs
+      .filter((r) => r.status === 'completed')
+      .reduce((s, r) => s + r.amountMxn, 0)
+    const lastRate = runs[0]?.rateSnapshotAnnualPercent ?? null
 
-  return NextResponse.json({
-    activeCycleId: meta.activeCycleId,
-    principalMxn,
-    lastReferenceAnnualRatePercent: lastRate,
-    recentRuns: runs,
-  })
+    return NextResponse.json({
+      activeCycleId: meta.activeCycleId,
+      principalMxn,
+      lastReferenceAnnualRatePercent: lastRate,
+      recentRuns: runs,
+    })
+  } catch (e) {
+    console.error('[api/seyf/invest/summary]', e)
+    return seyfInternalError()
+  }
 }

--- a/app/api/seyf/poc/ledger/route.ts
+++ b/app/api/seyf/poc/ledger/route.ts
@@ -1,5 +1,10 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import {
+  seyfApiError,
+  seyfErrorFromUnknown,
+  SEYF_VALIDATION_MESSAGE_ES,
+} from "@/lib/seyf/api-error";
 import { isEtherfuseDevPanelEnabled } from "@/lib/seyf/etherfuse-dev-panel";
 import {
   getPocLedgerSnapshot,
@@ -10,7 +15,7 @@ import { POC_USER_COOKIE, getOrCreatePocUserId } from "@/lib/seyf/poc-user-cooki
 
 function guardPoc(): NextResponse | null {
   if (!isEtherfuseDevPanelEnabled()) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+    return seyfApiError(404, "not_found");
   }
   return null;
 }
@@ -66,12 +71,12 @@ export async function POST(req: Request) {
   try {
     json = await req.json();
   } catch {
-    return NextResponse.json({ error: "JSON inválido" }, { status: 400 });
+    return seyfApiError(400, "bad_json");
   }
 
   const parsed = postSchema.safeParse(json);
   if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+    return seyfApiError(400, "validation_error", { message_es: SEYF_VALIDATION_MESSAGE_ES });
   }
 
   const memo =
@@ -92,7 +97,6 @@ export async function POST(req: Request) {
     }
     return res;
   } catch (e) {
-    const message = e instanceof Error ? e.message : "Error";
-    return NextResponse.json({ error: message }, { status: 400 });
+    return seyfErrorFromUnknown(e, 400);
   }
 }

--- a/app/api/seyf/stellar-movements/route.ts
+++ b/app/api/seyf/stellar-movements/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { seyfApiError, seyfErrorFromUnknown } from '@/lib/seyf/api-error'
 import {
   fetchChainMovements,
   type HorizonNetwork,
@@ -31,10 +32,14 @@ export async function GET(req: Request) {
   const { searchParams } = new URL(req.url)
   const account = (searchParams.get('account') ?? '').trim()
   if (!account) {
-    return NextResponse.json({ error: 'Falta account' }, { status: 400 })
+    return seyfApiError(400, 'validation_error', {
+      message_es: 'Falta el parámetro de cuenta pública.',
+    })
   }
   if (!looksLikeStellarAccount(account)) {
-    return NextResponse.json({ error: 'Cuenta Stellar inválida' }, { status: 400 })
+    return seyfApiError(400, 'validation_error', {
+      message_es: 'La cuenta pública no tiene un formato válido.',
+    })
   }
 
   const limitPerNet = 30
@@ -57,7 +62,6 @@ export async function GET(req: Request) {
       headers: { 'Cache-Control': 'no-store, max-age=0' },
     })
   } catch (e) {
-    const msg = e instanceof Error ? e.message : 'Horizon error'
-    return NextResponse.json({ error: msg }, { status: 502 })
+    return seyfErrorFromUnknown(e)
   }
 }

--- a/app/api/seyf/user-movements/route.ts
+++ b/app/api/seyf/user-movements/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { seyfErrorFromUnknown } from '@/lib/seyf/api-error'
 import { getEtherfuseRampContext } from '@/lib/seyf/etherfuse-ramp-context'
 import { fetchUserMovements } from '@/lib/seyf/user-movements'
 
@@ -6,9 +7,16 @@ export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
 export async function GET() {
-  const ctx = await getEtherfuseRampContext()
-  const movements = await fetchUserMovements(ctx)
-  return NextResponse.json({ movements }, {
-    headers: { 'Cache-Control': 'no-store, max-age=0' },
-  })
+  try {
+    const ctx = await getEtherfuseRampContext()
+    const movements = await fetchUserMovements(ctx)
+    return NextResponse.json(
+      { movements },
+      {
+        headers: { 'Cache-Control': 'no-store, max-age=0' },
+      },
+    )
+  } catch (e) {
+    return seyfErrorFromUnknown(e)
+  }
 }

--- a/app/api/webhooks/etherfuse/route.ts
+++ b/app/api/webhooks/etherfuse/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { seyfApiError } from "@/lib/seyf/api-error";
 import { verifyEtherfuseWebhookSignature } from "@/lib/etherfuse/webhook-verify";
 
 export const runtime = "nodejs";
@@ -16,7 +17,7 @@ export async function POST(req: Request) {
   try {
     payload = JSON.parse(raw) as unknown;
   } catch {
-    return NextResponse.json({ error: "JSON inválido" }, { status: 400 });
+    return seyfApiError(400, "bad_json");
   }
 
   const secret = process.env.ETHERFUSE_WEBHOOK_SECRET?.trim();
@@ -24,13 +25,15 @@ export async function POST(req: Request) {
 
   if (secret) {
     if (!verifyEtherfuseWebhookSignature(payload, sig, secret)) {
-      return NextResponse.json({ error: "Firma inválida" }, { status: 401 });
+      return seyfApiError(401, "unauthorized", {
+        message_es: "La firma del webhook no es válida.",
+      });
     }
   } else if (process.env.NODE_ENV === "production") {
-    return NextResponse.json(
-      { error: "ETHERFUSE_WEBHOOK_SECRET no configurado" },
-      { status: 503 },
-    );
+    return seyfApiError(503, "provider_unavailable", {
+      message_es: "El servicio de webhooks no está configurado correctamente en el servidor.",
+      retryable: false,
+    });
   }
 
   if (process.env.NODE_ENV !== "production") {

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { useEffect } from 'react'
+import { AppErrorFallback } from '@/components/errors/app-error-fallback'
+
+export default function RootError({
+  error,
+  reset: _reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error('[app-error]', error)
+  }, [error])
+
+  return (
+    <AppErrorFallback
+      title="No pudimos cargar esta parte"
+      description="Error inesperado. Vuelve al inicio o actualiza la página."
+    />
+  )
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -5,7 +5,7 @@ import { AppErrorFallback } from '@/components/errors/app-error-fallback'
 
 export default function RootError({
   error,
-  reset: _reset,
+  reset,
 }: {
   error: Error & { digest?: string }
   reset: () => void
@@ -18,6 +18,7 @@ export default function RootError({
     <AppErrorFallback
       title="No pudimos cargar esta parte"
       description="Error inesperado. Vuelve al inicio o actualiza la página."
+      onRetry={reset}
     />
   )
 }

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { useEffect } from 'react'
+import './globals.css'
+import { AppErrorFallback } from '@/components/errors/app-error-fallback'
+
+export default function GlobalError({
+  error,
+  reset: _reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error('[global-error]', error)
+  }, [error])
+
+  return (
+    <html lang="es" className="dark">
+      <body className="min-h-dvh bg-background font-sans antialiased text-foreground">
+        <AppErrorFallback
+          title="Algo salió mal"
+          description="Error grave. Vuelve al inicio o actualiza más tarde."
+        />
+      </body>
+    </html>
+  )
+}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -6,7 +6,7 @@ import { AppErrorFallback } from '@/components/errors/app-error-fallback'
 
 export default function GlobalError({
   error,
-  reset: _reset,
+  reset,
 }: {
   error: Error & { digest?: string }
   reset: () => void
@@ -21,6 +21,7 @@ export default function GlobalError({
         <AppErrorFallback
           title="Algo salió mal"
           description="Error grave. Vuelve al inicio o actualiza más tarde."
+          onRetry={reset}
         />
       </body>
     </html>

--- a/components/app/dashboard-client.tsx
+++ b/components/app/dashboard-client.tsx
@@ -22,6 +22,7 @@ import {
   DASHBOARD_MOVEMENTS_PREVIEW_LIMIT,
   type DashboardViewModel,
 } from '@/lib/seyf/dashboard-view-model-types'
+import { fetchWithSeyfRetryOnce } from '@/lib/seyf/read-client-api-error'
 import { formatMovementListSubtitle, type UserMovement } from '@/lib/seyf/user-movements-types'
 import { cn } from '@/lib/utils'
 
@@ -114,7 +115,7 @@ export default function DashboardClient({
     }
     let cancelled = false
     setStablebondCetes((s) => ({ ...s, loading: true }))
-    void fetch('/api/seyf/etherfuse/lookup/stablebonds?cetesOnly=1')
+    void fetchWithSeyfRetryOnce('/api/seyf/etherfuse/lookup/stablebonds?cetesOnly=1')
       .then(async (r) => {
         const data = (await r.json().catch(() => ({}))) as {
           cetes?: EtherfuseStablebondInfo | null
@@ -158,7 +159,7 @@ export default function DashboardClient({
       return
     }
     let cancelled = false
-    void fetch(`/api/seyf/stellar-movements?account=${encodeURIComponent(addr)}`)
+    void fetchWithSeyfRetryOnce(`/api/seyf/stellar-movements?account=${encodeURIComponent(addr)}`)
       .then(async (r) => {
         if (!r.ok) return [] as UserMovement[]
         const data = (await r.json()) as unknown
@@ -188,7 +189,7 @@ export default function DashboardClient({
 
   const refreshDashboard = useCallback(async () => {
     try {
-      const r = await fetch(pollBustUrl('/api/seyf/dashboard'), POLL_FETCH_INIT)
+      const r = await fetchWithSeyfRetryOnce(pollBustUrl('/api/seyf/dashboard'), POLL_FETCH_INIT)
       if (!r.ok) return
       const next = (await r.json()) as DashboardViewModel
       setLiveVm(next)

--- a/components/app/dev/etherfuse-order-cards.tsx
+++ b/components/app/dev/etherfuse-order-cards.tsx
@@ -32,7 +32,7 @@ export function DetailRow({
 /** Resumen de orden (API) + enlace a comprobante público si hay firma. */
 export function OrderTransactionDetailCard({ payloadJson }: { payloadJson: string }) {
   let orderDisplay: RampOrderTransactionDetails | null = null
-  let orderFetchError: string | null = null
+  let orderFetchFailed = false
   let orderRaw: unknown = null
   let pollAttempts: number | null = null
   let hasSandboxFiat = false
@@ -41,6 +41,8 @@ export function OrderTransactionDetailCard({ payloadJson }: { payloadJson: strin
   try {
     const root = JSON.parse(payloadJson) as {
       orderDisplay?: RampOrderTransactionDetails | null
+      orderFetchFailed?: boolean
+      /** @deprecated usar orderFetchFailed */
       orderFetchError?: string | null
       order?: unknown
       orderPolled?: unknown
@@ -54,8 +56,9 @@ export function OrderTransactionDetailCard({ payloadJson }: { payloadJson: strin
     hasOfframpTrack = root.offrampTrack === true
     hasSandboxFiat =
       root.sandboxFiatReceived !== undefined && root.sandboxFiatReceived !== null
-    orderFetchError =
-      typeof root.orderFetchError === 'string' ? root.orderFetchError : null
+    orderFetchFailed =
+      root.orderFetchFailed === true ||
+      (typeof root.orderFetchError === 'string' && root.orderFetchError.length > 0)
     orderRaw = root.orderPolled ?? root.orderAfterPoll ?? root.order ?? null
     pollAttempts = typeof root.pollAttempts === 'number' ? root.pollAttempts : null
     orderDisplay =
@@ -66,7 +69,7 @@ export function OrderTransactionDetailCard({ payloadJson }: { payloadJson: strin
   }
   if (
     !orderDisplay?.orderId &&
-    !orderFetchError &&
+    !orderFetchFailed &&
     !orderRaw &&
     !hasSandboxFiat &&
     !looksMxCetes &&
@@ -177,9 +180,9 @@ export function OrderTransactionDetailCard({ payloadJson }: { payloadJson: strin
           El comprobante público aparece cuando la operación avanza (pago o autorización completados).
         </p>
       )}
-      {orderFetchError ? (
+      {orderFetchFailed ? (
         <p className="mt-2 text-xs text-amber-600">
-          No se pudo actualizar el detalle: {orderFetchError}
+          No se pudo actualizar el detalle de la orden. Intenta de nuevo en unos segundos.
         </p>
       ) : null}
     </div>

--- a/components/app/dev/etherfuse-ramp-wallet-banner.tsx
+++ b/components/app/dev/etherfuse-ramp-wallet-banner.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
+import { getSeyfErrorDisplayMessage } from '@/lib/seyf/read-client-api-error'
 
 type RampContextPayload = {
   publicKey: string
@@ -10,7 +11,7 @@ type RampContextPayload = {
   source: 'cookie' | 'mvp_env'
   cryptoWalletId: string | null
   cryptoWalletResolved: boolean
-  cryptoWalletError: string | null
+  cryptoWalletResolveFailed?: boolean
 }
 
 /**
@@ -30,9 +31,9 @@ export function EtherfuseRampWalletBanner({
     setLoading(true)
     fetch('/api/seyf/etherfuse/ramp-context')
       .then(async (r) => {
-        const j = (await r.json()) as { error?: string } & Partial<RampContextPayload>
+        const j = (await r.json().catch(() => ({}))) as Partial<RampContextPayload> & Record<string, unknown>
         if (!r.ok) {
-          throw new Error(typeof j.error === 'string' ? j.error : r.statusText)
+          throw new Error(getSeyfErrorDisplayMessage(j, 'No se pudo cargar el contexto de rampa.'))
         }
         if (!cancelled) setData(j as RampContextPayload)
       })
@@ -118,8 +119,11 @@ export function EtherfuseRampWalletBanner({
           ) : (
             <span className="text-amber-600">
               pendiente — puede fallar el paso de autorización.{' '}
-              {data.cryptoWalletError ? (
-                <span className="block mt-1 text-[10px] opacity-90">{data.cryptoWalletError}</span>
+              {data.cryptoWalletResolveFailed ? (
+                <span className="block mt-1 text-[10px] opacity-90">
+                  No pudimos obtener el ID de wallet en Etherfuse. Comprueba que la clave esté registrada en el
+                  portal de prueba.
+                </span>
               ) : null}
             </span>
           )}

--- a/components/app/dev/etherfuse-ramp-wallet-banner.tsx
+++ b/components/app/dev/etherfuse-ramp-wallet-banner.tsx
@@ -2,7 +2,10 @@
 
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
-import { getSeyfErrorDisplayMessage } from '@/lib/seyf/read-client-api-error'
+import {
+  fetchWithSeyfRetryOnce,
+  getSeyfErrorDisplayMessage,
+} from '@/lib/seyf/read-client-api-error'
 
 type RampContextPayload = {
   publicKey: string
@@ -29,7 +32,7 @@ export function EtherfuseRampWalletBanner({
   useEffect(() => {
     let cancelled = false
     setLoading(true)
-    fetch('/api/seyf/etherfuse/ramp-context')
+    fetchWithSeyfRetryOnce('/api/seyf/etherfuse/ramp-context')
       .then(async (r) => {
         const j = (await r.json().catch(() => ({}))) as Partial<RampContextPayload> & Record<string, unknown>
         if (!r.ok) {

--- a/components/app/movement-detail-sheet.tsx
+++ b/components/app/movement-detail-sheet.tsx
@@ -4,7 +4,10 @@ import { useEffect, useState, type ReactNode } from 'react'
 import type { UserMovement } from '@/lib/seyf/user-movements-types'
 import { formatMovementFechaHora } from '@/lib/seyf/user-movements-types'
 import { stellarTxExplorerUrl } from '@/lib/etherfuse/stellar-tx-url'
-import { getSeyfErrorDisplayMessage } from '@/lib/seyf/read-client-api-error'
+import {
+  fetchWithSeyfRetryOnce,
+  getSeyfErrorDisplayMessage,
+} from '@/lib/seyf/read-client-api-error'
 
 function txSigFromOrderPayload(data: unknown): string | null {
   if (!data || typeof data !== 'object') return null
@@ -58,7 +61,9 @@ export function MovementDetailSheet({
 
     let cancelled = false
     setTxLoading(true)
-    void fetch(`/api/seyf/etherfuse/prueba/order/${encodeURIComponent(movement.orderId)}`)
+    void fetchWithSeyfRetryOnce(
+      `/api/seyf/etherfuse/prueba/order/${encodeURIComponent(movement.orderId)}`,
+    )
       .then(async (r) => {
         const data = await r.json().catch(() => ({}))
         if (!r.ok) {

--- a/components/app/movement-detail-sheet.tsx
+++ b/components/app/movement-detail-sheet.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, type ReactNode } from 'react'
 import type { UserMovement } from '@/lib/seyf/user-movements-types'
 import { formatMovementFechaHora } from '@/lib/seyf/user-movements-types'
 import { stellarTxExplorerUrl } from '@/lib/etherfuse/stellar-tx-url'
+import { getSeyfErrorDisplayMessage } from '@/lib/seyf/read-client-api-error'
 
 function txSigFromOrderPayload(data: unknown): string | null {
   if (!data || typeof data !== 'object') return null
@@ -61,17 +62,20 @@ export function MovementDetailSheet({
       .then(async (r) => {
         const data = await r.json().catch(() => ({}))
         if (!r.ok) {
-          throw new Error(typeof data.error === 'string' ? data.error : 'No se pudo cargar el comprobante')
+          if (!cancelled) {
+            setTxError(getSeyfErrorDisplayMessage(data, 'No se pudo cargar el comprobante.'))
+          }
+          return null
         }
         return data
       })
       .then((data) => {
-        if (cancelled) return
+        if (cancelled || !data) return
         const sig = txSigFromOrderPayload(data)
         if (sig) setResolvedSig(sig)
       })
-      .catch((e) => {
-        if (!cancelled) setTxError(e instanceof Error ? e.message : 'Error')
+      .catch(() => {
+        if (!cancelled) setTxError('No se pudo cargar el comprobante.')
       })
       .finally(() => {
         if (!cancelled) setTxLoading(false)

--- a/components/errors/app-error-fallback.tsx
+++ b/components/errors/app-error-fallback.tsx
@@ -7,15 +7,17 @@ import { Button } from '@/components/ui/button'
 type AppErrorFallbackProps = {
   title?: string
   description?: string
+  /** Reintenta el segmento (p. ej. `reset` de Next.js); botón secundario, no sustituye «Ir al inicio». */
+  onRetry?: () => void
 }
 
 /**
- * Pantalla de error sobria: una acción principal, sin CTAs de reintento que carguen la UI.
- * Recuperación: el usuario puede actualizar la página o seguir la navegación.
+ * Pantalla de error sobria: acción principal al inicio; opcionalmente reintento del segmento vía `onRetry`.
  */
 export function AppErrorFallback({
   title = 'Algo salió mal',
   description = 'Vuelve al inicio o actualiza la página.',
+  onRetry,
 }: AppErrorFallbackProps) {
   return (
     <div className="flex min-h-[70vh] flex-col items-center justify-center bg-background px-6 py-12 text-center">
@@ -28,6 +30,16 @@ export function AppErrorFallback({
         <Button asChild variant="default" className="h-11 w-full rounded-full font-semibold">
           <Link href="/dashboard">Ir al inicio</Link>
         </Button>
+        {onRetry ? (
+          <Button
+            type="button"
+            variant="outline"
+            className="h-11 w-full rounded-full font-semibold"
+            onClick={onRetry}
+          >
+            Intentar de nuevo
+          </Button>
+        ) : null}
         <Link
           href="/"
           className="text-sm font-medium text-muted-foreground underline-offset-4 transition hover:text-foreground hover:underline"

--- a/components/errors/app-error-fallback.tsx
+++ b/components/errors/app-error-fallback.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import Link from 'next/link'
+import { AlertTriangle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+type AppErrorFallbackProps = {
+  title?: string
+  description?: string
+}
+
+/**
+ * Pantalla de error sobria: una acción principal, sin CTAs de reintento que carguen la UI.
+ * Recuperación: el usuario puede actualizar la página o seguir la navegación.
+ */
+export function AppErrorFallback({
+  title = 'Algo salió mal',
+  description = 'Vuelve al inicio o actualiza la página.',
+}: AppErrorFallbackProps) {
+  return (
+    <div className="flex min-h-[70vh] flex-col items-center justify-center bg-background px-6 py-12 text-center">
+      <div className="relative mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-amber-500/15 ring-1 ring-amber-400/30">
+        <AlertTriangle className="size-8 text-amber-400" strokeWidth={2} />
+      </div>
+      <h1 className="text-2xl font-black tracking-tight text-foreground">{title}</h1>
+      <p className="mt-3 max-w-md text-sm leading-relaxed text-muted-foreground">{description}</p>
+      <div className="mt-10 flex w-full max-w-xs flex-col items-center gap-4">
+        <Button asChild variant="default" className="h-11 w-full rounded-full font-semibold">
+          <Link href="/dashboard">Ir al inicio</Link>
+        </Button>
+        <Link
+          href="/"
+          className="text-sm font-medium text-muted-foreground underline-offset-4 transition hover:text-foreground hover:underline"
+        >
+          Inicio público
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -8,7 +8,7 @@
 | Códigos `spei_timeout`, `deploy_failed`, `advance_limit_exceeded`, `kyc_pending`, `insufficient_balance`, `provider_unavailable` | Definidos en `SEYF_API_ERROR_CODES` y tabla abajo; más códigos auxiliares (`validation_error`, `unauthorized`, etc.). |
 | Error boundary global con pantalla amable | `app/error.tsx`, `app/global-error.tsx`, `app/(app)/error.tsx` + `components/errors/app-error-fallback.tsx`. |
 | Sin mensajes crudos de Stellar / Etherfuse / Pollar en UI | Las rutas usan `seyfErrorFromUnknown` (solo log en servidor). Clientes que llaman a esas APIs usan `getSeyfErrorDisplayMessage` / `extractSeyfApiError` (p. ej. depósito, ramp dev, PoC, movimiento, prueba MXN-CETES). |
-| `retryable` en JSON | El campo se expone para clientes que reintenten en **segundo plano** (polling, re-fetch) sin añadir botones extra en la UI; la app mantiene pantallas de error **sobrias** (navegación a inicio, sin CTA de reintento prominente). |
+| `retryable` en JSON | El campo guía **un reintento automático** en cliente (`fetchWithSeyfRetryOnce` en `read-client-api-error.ts`) en llamadas a `/api/seyf/**`. Los boundaries (`error.tsx` / `global-error.tsx`) ofrecen además **«Intentar de nuevo»** secundario (`reset` de Next.js), sin sustituir «Ir al inicio». |
 | 500 genérico «Algo salió mal. Estamos en ello.» sin stack en JSON | `seyfInternalError()` en `api-error.ts`. |
 | Documentación en `/docs/error-codes.md` | Este archivo. |
 
@@ -53,7 +53,7 @@ Los clientes **no** deben mostrar `Error.message` crudo de Stellar, Etherfuse ni
 ## UI
 
 - **`message_es`**: mostrar como texto informativo (toast, banner o mensaje bajo el campo); tono profesional, sin listas de botones.
-- **`retryable`**: usar solo para lógica (p. ej. reintentar `fetch` automáticamente una vez, o seguir polling), no como excusa para apilar CTAs en pantalla.
+- **`retryable`**: un segundo `fetch` tras ~450 ms si el servidor devolvió error Seyf con `retryable: true`; en formularios y banners que ya usan `getSeyfErrorDisplayMessage`, las peticiones van con `fetchWithSeyfRetryOnce`. En pantallas de error de segmento, «Intentar de nuevo» re-ejecuta el árbol de React del segmento.
 
 ## Referencias
 

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1,0 +1,61 @@
+# Códigos de error API Seyf
+
+## Criterios de aceptación (#37) — estado
+
+| Criterio | Estado |
+|----------|--------|
+| Todas las rutas API devuelven `{ error: { code, message_es, retryable } }` | Cumplido en `app/api/seyf/**` y `app/api/webhooks/etherfuse` vía `lib/seyf/api-error.ts`. |
+| Códigos `spei_timeout`, `deploy_failed`, `advance_limit_exceeded`, `kyc_pending`, `insufficient_balance`, `provider_unavailable` | Definidos en `SEYF_API_ERROR_CODES` y tabla abajo; más códigos auxiliares (`validation_error`, `unauthorized`, etc.). |
+| Error boundary global con pantalla amable | `app/error.tsx`, `app/global-error.tsx`, `app/(app)/error.tsx` + `components/errors/app-error-fallback.tsx`. |
+| Sin mensajes crudos de Stellar / Etherfuse / Pollar en UI | Las rutas usan `seyfErrorFromUnknown` (solo log en servidor). Clientes que llaman a esas APIs usan `getSeyfErrorDisplayMessage` / `extractSeyfApiError` (p. ej. depósito, ramp dev, PoC, movimiento, prueba MXN-CETES). |
+| `retryable` en JSON | El campo se expone para clientes que reintenten en **segundo plano** (polling, re-fetch) sin añadir botones extra en la UI; la app mantiene pantallas de error **sobrias** (navegación a inicio, sin CTA de reintento prominente). |
+| 500 genérico «Algo salió mal. Estamos en ello.» sin stack en JSON | `seyfInternalError()` en `api-error.ts`. |
+| Documentación en `/docs/error-codes.md` | Este archivo. |
+
+Todas las rutas bajo `/api/seyf/**` y webhooks relacionados deben devolver errores con esta forma:
+
+```json
+{
+  "error": {
+    "code": "<código>",
+    "message_es": "<texto seguro en español>",
+    "retryable": true | false
+  }
+}
+```
+
+Los clientes **no** deben mostrar `Error.message` crudo de Stellar, Etherfuse ni Pollar: solo `message_es` (y opcionalmente `code` para lógica).
+
+## Códigos
+
+| Código | `retryable` típico | Uso |
+|--------|-------------------|-----|
+| `spei_timeout` | `true` | SPEI / transferencia tardó demasiado o timeout de red. |
+| `deploy_failed` | `true` | Fallo al ejecutar contrato / transacción en Stellar (mensaje al usuario genérico). |
+| `advance_limit_exceeded` | `false` | Adelanto fuera de límites de negocio. |
+| `kyc_pending` | `false` | Identidad pendiente o incompleta. |
+| `insufficient_balance` | `false` | Saldo insuficiente (XLM, MXNe, etc.). |
+| `provider_unavailable` | `true` | Proveedor (Etherfuse, Horizon, etc.) no disponible o error 5xx upstream. |
+| `validation_error` | `false` | Cuerpo o parámetros inválidos (Zod, reglas de negocio). |
+| `unauthorized` | `false` | Falta sesión, cookie o contexto (p. ej. rampa sin identidad). |
+| `forbidden` | `false` | Acción no permitida en este entorno (feature flag, producción). |
+| `not_found` | `false` | Recurso inexistente. |
+| `conflict` | `false` | Estado incompatible (p. ej. orden pendiente). |
+| `internal_error` | `false` | Error interno no clasificado; mensaje genérico, sin stack en JSON. |
+| `bad_json` | `false` | Cuerpo no es JSON válido. |
+
+## HTTP
+
+- **4xx**: errores de cliente / negocio; suelen ser `retryable: false` salvo políticas explícitas.
+- **5xx**: servidor o upstream; `internal_error` usa mensaje fijo en español sin filtrar detalles técnicos.
+- **502 / 503 / 504**: a menudo mapean a `provider_unavailable` o `spei_timeout` con `retryable: true` cuando aplica.
+
+## UI
+
+- **`message_es`**: mostrar como texto informativo (toast, banner o mensaje bajo el campo); tono profesional, sin listas de botones.
+- **`retryable`**: usar solo para lógica (p. ej. reintentar `fetch` automáticamente una vez, o seguir polling), no como excusa para apilar CTAs en pantalla.
+
+## Referencias
+
+- Issue: Global Error Handling & User-Facing Error Messages (#37)
+- PRD §2.8 US-12

--- a/lib/seyf/api-error.ts
+++ b/lib/seyf/api-error.ts
@@ -1,0 +1,148 @@
+import { NextResponse } from 'next/server'
+
+/** Códigos acordados (issue #37 / PRD US-12). */
+export const SEYF_API_ERROR_CODES = [
+  'spei_timeout',
+  'deploy_failed',
+  'advance_limit_exceeded',
+  'kyc_pending',
+  'insufficient_balance',
+  'provider_unavailable',
+  'validation_error',
+  'unauthorized',
+  'forbidden',
+  'not_found',
+  'conflict',
+  'internal_error',
+  'bad_json',
+] as const
+
+export type SeyfApiErrorCode = (typeof SEYF_API_ERROR_CODES)[number]
+
+export type SeyfApiErrorPayload = {
+  error: {
+    code: SeyfApiErrorCode
+    message_es: string
+    retryable: boolean
+  }
+}
+
+const GENERIC_500_ES =
+  'Algo salió mal. Estamos en ello. Si persiste, intenta más tarde o contacta a soporte.'
+
+/** Mensajes seguros por código (nunca exponen proveedor ni Stellar en bruto). */
+export const SEYF_API_ERROR_MESSAGES: Record<SeyfApiErrorCode, string> = {
+  spei_timeout:
+    'La operación con SPEI tardó demasiado. Puedes intentar de nuevo en unos minutos.',
+  deploy_failed:
+    'No pudimos completar la operación en la red. Intenta de nuevo o revisa tu saldo y permisos.',
+  advance_limit_exceeded:
+    'El monto supera el adelanto disponible con las reglas actuales. Ajusta el importe o el plazo.',
+  kyc_pending:
+    'Tu identidad aún está en revisión o falta completarla. Termina el proceso en Identidad.',
+  insufficient_balance:
+    'Saldo insuficiente para esta operación. Agrega fondos e inténtalo de nuevo.',
+  provider_unavailable:
+    'El servicio no respondió a tiempo. Intenta de nuevo en un momento.',
+  validation_error: 'Los datos enviados no son válidos. Revisa el formulario e inténtalo de nuevo.',
+  unauthorized: 'Necesitas iniciar sesión o vincular tu cuenta para continuar.',
+  forbidden: 'No tienes permiso para esta acción en este entorno.',
+  not_found: 'No encontramos el recurso solicitado.',
+  conflict: 'Esta operación choca con un estado previo (por ejemplo, un proceso pendiente).',
+  internal_error: GENERIC_500_ES,
+  bad_json: 'El cuerpo de la petición no es JSON válido.',
+}
+
+export function seyfApiError(
+  status: number,
+  code: SeyfApiErrorCode,
+  opts?: { message_es?: string; retryable?: boolean },
+): NextResponse<SeyfApiErrorPayload> {
+  const retryable = opts?.retryable ?? defaultRetryable(code)
+  const message_es = opts?.message_es ?? SEYF_API_ERROR_MESSAGES[code]
+  return NextResponse.json({ error: { code, message_es, retryable } }, { status })
+}
+
+export function defaultRetryable(code: SeyfApiErrorCode): boolean {
+  switch (code) {
+    case 'spei_timeout':
+    case 'provider_unavailable':
+      return true
+    default:
+      return false
+  }
+}
+
+/** Respuesta 500 genérica sin stack ni detalles técnicos. */
+export function seyfInternalError(): NextResponse<SeyfApiErrorPayload> {
+  if (process.env.NODE_ENV !== 'production') {
+    console.error('[seyf-api] internal_error (detalle solo en servidor)')
+  }
+  return seyfApiError(500, 'internal_error', { message_es: GENERIC_500_ES, retryable: false })
+}
+
+function norm(s: string) {
+  return s.toLowerCase()
+}
+
+/**
+ * Convierte un error desconocido (SDK, fetch, etc.) en respuesta HTTP segura para el cliente.
+ * Registra el error original solo en consola del servidor.
+ */
+export function seyfErrorFromUnknown(
+  e: unknown,
+  fallbackStatus = 502,
+): NextResponse<SeyfApiErrorPayload> {
+  console.error('[seyf-api]', e)
+
+  const raw = e instanceof Error ? e.message : typeof e === 'string' ? e : ''
+  const m = norm(raw)
+
+  if (m.includes('timeout') || m.includes('timed out') || m.includes('etimedout')) {
+    return seyfApiError(504, 'spei_timeout', { retryable: true })
+  }
+  if (m.includes('insufficient') || m.includes('underfunded') || m.includes('op_low_reserve')) {
+    return seyfApiError(400, 'insufficient_balance', { retryable: false })
+  }
+  if (m.includes('kyc') || m.includes('verification') || m.includes('identity')) {
+    return seyfApiError(403, 'kyc_pending', { retryable: false })
+  }
+  if (m.includes('advance') || m.includes('limit exceeded') || m.includes('límite')) {
+    return seyfApiError(400, 'advance_limit_exceeded', { retryable: false })
+  }
+  if (
+    m.includes('deploy') ||
+    m.includes('soroban') ||
+    m.includes('invokehostfunction') ||
+    m.includes('tx_failed')
+  ) {
+    return seyfApiError(502, 'deploy_failed', { retryable: true })
+  }
+  if (
+    m.includes('econnrefused') ||
+    m.includes('enotfound') ||
+    m.includes('fetch failed') ||
+    m.includes('503') ||
+    m.includes('502') ||
+    m.includes('bad gateway') ||
+    m.includes('service unavailable')
+  ) {
+    return seyfApiError(fallbackStatus >= 500 ? fallbackStatus : 503, 'provider_unavailable', {
+      retryable: true,
+    })
+  }
+
+  if (fallbackStatus >= 500) {
+    return seyfInternalError()
+  }
+  if (fallbackStatus === 400) {
+    return seyfApiError(400, 'validation_error', { message_es: SEYF_VALIDATION_MESSAGE_ES })
+  }
+  return seyfApiError(fallbackStatus, 'provider_unavailable', { retryable: true })
+}
+
+export const SEYF_VALIDATION_MESSAGE_ES = SEYF_API_ERROR_MESSAGES.validation_error
+
+/** Sin cookie /identidad ni contexto MVP: mismo mensaje en todas las rutas rampa. */
+export const SEYF_RAMP_UNAUTHORIZED_MESSAGE_ES =
+  'Para usar depósitos y retiros necesitas una sesión vinculada. Inicia con Accesly desde el inicio o completa Identidad.'

--- a/lib/seyf/etherfuse-ramp-guard.ts
+++ b/lib/seyf/etherfuse-ramp-guard.ts
@@ -1,4 +1,5 @@
-import { NextResponse } from "next/server";
+import type { NextResponse } from "next/server";
+import { seyfApiError } from "@/lib/seyf/api-error";
 
 /**
  * Igual que el mock de inversión: en producción la rampa vía API solo si se habilita explícitamente.
@@ -8,13 +9,10 @@ export function guardEtherfuseRampRoutes(): NextResponse | null {
     process.env.NODE_ENV === "production" &&
     process.env.SEYF_ALLOW_ETHERFUSE_RAMP !== "true"
   ) {
-    return NextResponse.json(
-      {
-        error:
-          "Rampa Etherfuse deshabilitada en producción. Establece SEYF_ALLOW_ETHERFUSE_RAMP=true o usa otro entorno.",
-      },
-      { status: 403 },
-    );
+    return seyfApiError(403, "forbidden", {
+      message_es:
+        "La rampa de depósito/retiro no está disponible en este entorno. Contacta al equipo si necesitas usarla.",
+    });
   }
   return null;
 }

--- a/lib/seyf/read-client-api-error.ts
+++ b/lib/seyf/read-client-api-error.ts
@@ -34,3 +34,26 @@ export function getSeyfErrorDisplayMessage(json: unknown, fallbackEs = 'No pudim
 export function getSeyfErrorRetryable(json: unknown): boolean | null {
   return extractSeyfApiError(json)?.retryable ?? null
 }
+
+const SEYF_RETRY_BACKOFF_MS = 450
+
+/**
+ * Si la primera respuesta es error Seyf con `retryable: true`, espera un instante y repite el `fetch` una sola vez.
+ * Útil para `provider_unavailable`, `spei_timeout`, `deploy_failed`, etc.
+ */
+export async function fetchWithSeyfRetryOnce(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> {
+  const first = await fetch(input, init)
+  if (first.ok) return first
+  let parsed: unknown
+  try {
+    parsed = await first.clone().json()
+  } catch {
+    return first
+  }
+  if (getSeyfErrorRetryable(parsed) !== true) return first
+  await new Promise((r) => setTimeout(r, SEYF_RETRY_BACKOFF_MS))
+  return fetch(input, init)
+}

--- a/lib/seyf/read-client-api-error.ts
+++ b/lib/seyf/read-client-api-error.ts
@@ -1,0 +1,36 @@
+import type { SeyfApiErrorCode, SeyfApiErrorPayload } from '@/lib/seyf/api-error'
+
+export type SeyfClientApiError = SeyfApiErrorPayload['error']
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}
+
+/** Detecta el cuerpo `{ error: { code, message_es, retryable } }` devuelto por las rutas Seyf. */
+export function extractSeyfApiError(json: unknown): SeyfClientApiError | null {
+  if (!isRecord(json)) return null
+  const err = json.error
+  if (!isRecord(err)) return null
+  const code = err.code
+  const message_es = err.message_es
+  const retryable = err.retryable
+  if (typeof code !== 'string' || typeof message_es !== 'string' || typeof retryable !== 'boolean') {
+    return null
+  }
+  return { code: code as SeyfApiErrorCode, message_es, retryable }
+}
+
+/** Mensaje seguro para UI: usa payload Seyf o un fallback genérico (nunca muestra string técnico legacy). */
+export function getSeyfErrorDisplayMessage(json: unknown, fallbackEs = 'No pudimos completar la acción.'): string {
+  const parsed = extractSeyfApiError(json)
+  if (parsed) return parsed.message_es
+  if (isRecord(json) && typeof json.error === 'string') {
+    return fallbackEs
+  }
+  return fallbackEs
+}
+
+/** Para CTAs: `true` / `false` si el cuerpo es error Seyf; si no, `null` (p. ej. HTML o formato viejo). */
+export function getSeyfErrorRetryable(json: unknown): boolean | null {
+  return extractSeyfApiError(json)?.retryable ?? null
+}


### PR DESCRIPTION
## Resumen
Implementación del issue #37 (ya cerrado): respuestas `{ error: { code, message_es, retryable } }` en `/api/seyf/**`, boundaries con fallback en español, lectura segura en cliente y reintentos (`fetchWithSeyfRetryOnce` + botón «Intentar de nuevo» con `reset`).

## Referencias
- Closes: trabajo asociado a #37
- Docs: `docs/error-codes.md`

Made with [Cursor](https://cursor.com)