### PR TITLE
feat(M04-T01): Stellar wallet provisioning via Pollar

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ Copy **`.env.example`** → **`.env.local`**. Do not commit secrets.
 | `SEYF_ALLOW_KYC_RESET` | Enables “reset trial” UI on `/identidad` outside development. |
 | `SEYF_ETHERFUSE_DEV_PANEL` | `true` to show Etherfuse dev panels outside `NODE_ENV=development`. |
 | `SEYF_SPEI_DISPLAY_NAME` | Label for sandbox SPEI UI (default Etherfuse). |
+| `POLLAR_API_KEY` | Server-side Pollar API key for wallet provisioning (never expose as `NEXT_PUBLIC_*`). |
+| `POLLAR_API_BASE_URL` | Server-side Pollar base URL for wallet provisioning requests. |
+| `STELLAR_NETWORK` | Provisioning network for server wallet creation (`testnet` default). |
+| `ADMIN_ALERT_WEBHOOK_URL` | Optional admin alert webhook when wallet provisioning exhausts retries. |
 
 ### Client — `NEXT_PUBLIC_*`
 
@@ -279,6 +283,7 @@ scripts/             # verify-etherfuse.mjs, …
 |------------------|---------|
 | `/api/seyf/dashboard` | **DashboardViewModel** JSON. |
 | `/api/seyf/user-movements` | Movements (Etherfuse + optional MVP ledger depending on env). |
+| `/api/seyf/wallet/status` | Current wallet provisioning status for the authenticated `/identidad` session. |
 | `/api/seyf/stellar-movements?account=G...` | Horizon **testnet + mainnet** → `UserMovement[]`. |
 | `/api/seyf/etherfuse/*` | Quotes, orders, assets, ramp context, mxn-cetes trials, sandbox `fiat-received`, … |
 | `/api/seyf/invest`, `/api/seyf/invest/summary` | MVP invest (gated in prod without `SEYF_ALLOW_MOCK_INVEST`). |

--- a/__tests__/lib/seyf/pollar-wallet-provision.test.ts
+++ b/__tests__/lib/seyf/pollar-wallet-provision.test.ts
@@ -1,0 +1,184 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { isWalletActive, provisionWalletForUser } from '../../../lib/seyf/pollar-wallet-provision'
+
+type MockResponse = {
+  ok: boolean
+  status: number
+  text: () => Promise<string>
+}
+
+function okJson(body: unknown): MockResponse {
+  return {
+    ok: true,
+    status: 200,
+    text: async () => JSON.stringify(body),
+  }
+}
+
+function failText(status = 500, body = 'boom'): MockResponse {
+  return {
+    ok: false,
+    status,
+    text: async () => body,
+  }
+}
+
+function withMockedTimers() {
+  const original = globalThis.setTimeout
+  ;(globalThis as { setTimeout: typeof setTimeout }).setTimeout = ((fn: (...args: unknown[]) => void) => {
+    fn()
+    return 0 as unknown as ReturnType<typeof setTimeout>
+  }) as typeof setTimeout
+  return () => {
+    ;(globalThis as { setTimeout: typeof setTimeout }).setTimeout = original
+  }
+}
+
+test('returns status active + wallet data on first-attempt success', async () => {
+  const originalFetch = globalThis.fetch
+  const originalApiKey = process.env.POLLAR_API_KEY
+  const originalBaseUrl = process.env.POLLAR_API_BASE_URL
+  const originalNetwork = process.env.STELLAR_NETWORK
+  process.env.POLLAR_API_KEY = 'secret_key'
+  process.env.POLLAR_API_BASE_URL = 'https://pollar.example'
+  process.env.STELLAR_NETWORK = 'testnet'
+
+  globalThis.fetch = (async () =>
+    okJson({
+      id: 'wallet_1',
+      stellar_public_key: 'GTESTPUBLICKEY123',
+      private_key: 'never-should-be-returned',
+    })) as unknown as typeof fetch
+
+  try {
+    const result = await provisionWalletForUser('user-1')
+    assert.equal(result.status, 'active')
+    assert.equal(result.pollarWalletId, 'wallet_1')
+    assert.equal(result.stellarPublicKey, 'GTESTPUBLICKEY123')
+    assert.equal('private_key' in (result as Record<string, unknown>), false)
+    assert.equal('seed' in (result as Record<string, unknown>), false)
+    assert.equal('mnemonic' in (result as Record<string, unknown>), false)
+  } finally {
+    globalThis.fetch = originalFetch
+    process.env.POLLAR_API_KEY = originalApiKey
+    process.env.POLLAR_API_BASE_URL = originalBaseUrl
+    process.env.STELLAR_NETWORK = originalNetwork
+  }
+})
+
+test('sends expected Authorization header and body payload', async () => {
+  const originalFetch = globalThis.fetch
+  const originalApiKey = process.env.POLLAR_API_KEY
+  const originalBaseUrl = process.env.POLLAR_API_BASE_URL
+  const originalNetwork = process.env.STELLAR_NETWORK
+  process.env.POLLAR_API_KEY = 'api_k'
+  process.env.POLLAR_API_BASE_URL = 'https://api.example'
+  process.env.STELLAR_NETWORK = 'mainnet'
+
+  let capturedInit: RequestInit | undefined
+  let capturedUrl = ''
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    capturedInit = init
+    capturedUrl = String(input)
+    return okJson({
+      wallet_id: 'w_2',
+      public_key: 'GPUBLIC2',
+    })
+  }) as unknown as typeof fetch
+
+  try {
+    await provisionWalletForUser('u-2')
+    assert.equal(capturedUrl, 'https://api.example/wallets')
+    assert.equal((capturedInit?.headers as Record<string, string>).Authorization, 'Bearer api_k')
+    const body = JSON.parse(String(capturedInit?.body)) as Record<string, unknown>
+    assert.equal(body.external_id, 'u-2')
+    assert.equal(body.custody, 'embedded')
+    assert.equal(body.network, 'mainnet')
+  } finally {
+    globalThis.fetch = originalFetch
+    process.env.POLLAR_API_KEY = originalApiKey
+    process.env.POLLAR_API_BASE_URL = originalBaseUrl
+    process.env.STELLAR_NETWORK = originalNetwork
+  }
+})
+
+test('retries on failure and succeeds on second attempt', async () => {
+  const restoreTimers = withMockedTimers()
+  const originalFetch = globalThis.fetch
+  const originalApiKey = process.env.POLLAR_API_KEY
+  process.env.POLLAR_API_KEY = 'retry_key'
+
+  let attempts = 0
+  globalThis.fetch = (async () => {
+    attempts += 1
+    if (attempts === 1) {
+      return failText(503, 'temporary outage')
+    }
+    return okJson({
+      pollarWalletId: 'wallet_retry',
+      stellarPublicKey: 'GRETRYKEY',
+    })
+  }) as unknown as typeof fetch
+
+  try {
+    const result = await provisionWalletForUser('retry-user')
+    assert.equal(result.status, 'active')
+    assert.equal(result.pollarWalletId, 'wallet_retry')
+    assert.equal(attempts, 2)
+  } finally {
+    restoreTimers()
+    globalThis.fetch = originalFetch
+    process.env.POLLAR_API_KEY = originalApiKey
+  }
+})
+
+test('returns status error after all retries are exhausted', async () => {
+  const restoreTimers = withMockedTimers()
+  const originalFetch = globalThis.fetch
+  const originalApiKey = process.env.POLLAR_API_KEY
+  const originalWebhook = process.env.ADMIN_ALERT_WEBHOOK_URL
+  process.env.POLLAR_API_KEY = 'retry_key'
+  delete process.env.ADMIN_ALERT_WEBHOOK_URL
+
+  let attempts = 0
+  globalThis.fetch = (async () => {
+    attempts += 1
+    return failText(500, 'still down')
+  }) as unknown as typeof fetch
+
+  try {
+    const result = await provisionWalletForUser('error-user')
+    assert.equal(result.status, 'error')
+    assert.equal(result.pollarWalletId, '')
+    assert.equal(result.stellarPublicKey, '')
+    assert.equal(attempts, 4)
+  } finally {
+    restoreTimers()
+    globalThis.fetch = originalFetch
+    process.env.POLLAR_API_KEY = originalApiKey
+    process.env.ADMIN_ALERT_WEBHOOK_URL = originalWebhook
+  }
+})
+
+test('throws if POLLAR_API_KEY is not set', async () => {
+  const originalApiKey = process.env.POLLAR_API_KEY
+  delete process.env.POLLAR_API_KEY
+
+  try {
+    await assert.rejects(
+      provisionWalletForUser('no-key-user'),
+      /POLLAR_API_KEY is required to provision wallets/,
+    )
+  } finally {
+    process.env.POLLAR_API_KEY = originalApiKey
+  }
+})
+
+test('isWalletActive returns true only for active status', () => {
+  assert.equal(isWalletActive({ status: 'active' }), true)
+  assert.equal(isWalletActive({ status: 'provisioning' }), false)
+  assert.equal(isWalletActive({ status: 'error' }), false)
+  assert.equal(isWalletActive(null), false)
+  assert.equal(isWalletActive(undefined), false)
+})

--- a/app/(app)/identidad/actions.ts
+++ b/app/(app)/identidad/actions.ts
@@ -13,6 +13,10 @@ import {
   normalizeStellarPublicKey,
 } from '@/lib/etherfuse/stellar-public-key'
 import { isKycTestResetEnabled } from '@/lib/seyf/kyc-test-reset'
+import {
+  assertWalletActiveForUser,
+  triggerWalletProvisioningForUser,
+} from '@/lib/seyf/wallet-provisioning'
 
 export type StartHostedOnboardingResult =
   | { ok: true; url: string }
@@ -66,4 +70,12 @@ export async function resetKycTestSession(): Promise<ResetKycTestSessionResult> 
   }
   await clearEtherfuseOnboardingSession()
   return { ok: true }
+}
+
+export async function triggerWalletProvisioning(userId: string): Promise<void> {
+  await triggerWalletProvisioningForUser(userId)
+}
+
+export async function assertWalletActive(userId: string): Promise<void> {
+  await assertWalletActiveForUser(userId)
 }

--- a/app/(app)/identidad/page.tsx
+++ b/app/(app)/identidad/page.tsx
@@ -2,6 +2,7 @@ import { getEtherfuseOnboardingSession } from '@/lib/etherfuse/onboarding-sessio
 import { fetchEtherfuseKycStatus } from '@/lib/etherfuse/kyc'
 import type { EtherfuseKycSnapshot } from '@/lib/etherfuse/kyc'
 import { isKycTestResetEnabled } from '@/lib/seyf/kyc-test-reset'
+import { triggerWalletProvisioning } from './actions'
 import IdentidadClient from './identidad-client'
 
 export default async function IdentidadPage() {
@@ -11,7 +12,12 @@ export default async function IdentidadPage() {
   if (session) {
     try {
       const r = await fetchEtherfuseKycStatus(session.customerId, session.publicKey)
-      if (r.ok) initialKyc = r.data
+      if (r.ok) {
+        initialKyc = r.data
+        if (r.data.status === 'approved' || r.data.status === 'approved_chain_deploying') {
+          await triggerWalletProvisioning(session.customerId)
+        }
+      }
     } catch {
       initialKyc = null
     }

--- a/app/api/seyf/etherfuse/mvp/onramp/route.ts
+++ b/app/api/seyf/etherfuse/mvp/onramp/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { executeMvpPartnerOnramp } from "@/lib/etherfuse/mvp-onramp";
+import { resolveMvpPartnerRampIdentity } from "@/lib/etherfuse/partner-accounts";
 import { toErrorResponse } from "@/lib/seyf/api-error";
 import { guardEtherfuseRampRoutes } from "@/lib/seyf/etherfuse-ramp-guard";
+import { assertWalletActiveForUser } from "@/lib/seyf/wallet-provisioning";
 
 const bodySchema = z.object({
   sourceAmount: z.string().min(1),
@@ -40,10 +42,13 @@ export async function POST(req: Request) {
   }
 
   try {
+    const identity = await resolveMvpPartnerRampIdentity();
+    await assertWalletActiveForUser(identity.customerId);
     const result = await executeMvpPartnerOnramp({
       sourceAmount: parsed.data.sourceAmount,
       amountMxn: mxn,
       forceNew: parsed.data.forceNew === true,
+      identity,
     });
     return NextResponse.json(result);
   } catch (e) {

--- a/app/api/seyf/etherfuse/order/offramp/route.ts
+++ b/app/api/seyf/etherfuse/order/offramp/route.ts
@@ -6,6 +6,7 @@ import { createMxOfframpOrder } from "@/lib/etherfuse/ramp-api";
 import { AppError, toErrorResponse } from "@/lib/seyf/api-error";
 import { getEtherfuseRampContext } from "@/lib/seyf/etherfuse-ramp-context";
 import { guardEtherfuseRampRoutes } from "@/lib/seyf/etherfuse-ramp-guard";
+import { assertWalletActiveForUser } from "@/lib/seyf/wallet-provisioning";
 
 const bodySchema = z.object({
   quoteId: z.string().uuid(),
@@ -45,6 +46,7 @@ export async function POST(req: Request) {
   }
 
   try {
+    await assertWalletActiveForUser(ctx.customerId);
     let cryptoWalletId: string | undefined;
     try {
       cryptoWalletId = await resolveMvpPartnerCryptoWalletId(ctx.publicKey);

--- a/app/api/seyf/etherfuse/order/onramp/route.ts
+++ b/app/api/seyf/etherfuse/order/onramp/route.ts
@@ -6,6 +6,7 @@ import { createMxOnrampOrder } from "@/lib/etherfuse/ramp-api";
 import { AppError, toErrorResponse } from "@/lib/seyf/api-error";
 import { getEtherfuseRampContext } from "@/lib/seyf/etherfuse-ramp-context";
 import { guardEtherfuseRampRoutes } from "@/lib/seyf/etherfuse-ramp-guard";
+import { assertWalletActiveForUser } from "@/lib/seyf/wallet-provisioning";
 
 const bodySchema = z.object({
   quoteId: z.string().uuid(),
@@ -43,6 +44,7 @@ export async function POST(req: Request) {
   }
 
   try {
+    await assertWalletActiveForUser(ctx.customerId);
     let cryptoWalletId: string | undefined;
     try {
       cryptoWalletId = await resolveMvpPartnerCryptoWalletId(ctx.publicKey);

--- a/app/api/seyf/etherfuse/prueba/mxn-cetes/route.ts
+++ b/app/api/seyf/etherfuse/prueba/mxn-cetes/route.ts
@@ -18,6 +18,7 @@ import { toErrorMessage, toErrorResponse } from "@/lib/seyf/api-error";
 import { getEtherfuseRampContext } from "@/lib/seyf/etherfuse-ramp-context";
 import { isEtherfuseDevPanelEnabled } from "@/lib/seyf/etherfuse-dev-panel";
 import { guardEtherfuseRampRoutes } from "@/lib/seyf/etherfuse-ramp-guard";
+import { assertWalletActiveForUser } from "@/lib/seyf/wallet-provisioning";
 
 /**
  * Onramp MXN (fiat) → CETES en Stellar (sandbox / devnet).
@@ -91,6 +92,7 @@ export async function POST(req: Request) {
           contextSource = "mvp_env";
         }
       }
+      await assertWalletActiveForUser(identity.customerId);
     } catch (e) {
       return toErrorResponse(e, "mxn-cetes/identity");
     }

--- a/app/api/seyf/invest/route.ts
+++ b/app/api/seyf/invest/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { runMockAutoInvest } from '@/lib/seyf/investment-mvp'
 import { notifyUser } from '@/lib/seyf/notifications/notify'
+import { assertWalletActiveForUser } from '@/lib/seyf/wallet-provisioning'
 
 const bodySchema = z.object({
   depositId: z.string().min(1),
@@ -34,7 +35,14 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
   }
 
-  const result = await runMockAutoInvest(parsed.data)
+  let result: Awaited<ReturnType<typeof runMockAutoInvest>>
+  try {
+    await assertWalletActiveForUser(parsed.data.userId)
+    result = await runMockAutoInvest(parsed.data)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'No se pudo iniciar la inversión.'
+    return NextResponse.json({ error: message }, { status: 409 })
+  }
 
   if (result.createdNew) {
     void notifyUser(parsed.data.userId, 'deposit_deployed', {

--- a/app/api/seyf/wallet/status/route.ts
+++ b/app/api/seyf/wallet/status/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server'
+import { getEtherfuseOnboardingSession } from '@/lib/etherfuse/onboarding-session'
+import { getUserWalletByUserId } from '@/lib/seyf/user-wallets'
+
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export async function GET() {
+  const session = await getEtherfuseOnboardingSession()
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const row = await getUserWalletByUserId(session.customerId)
+    const status = row?.status ?? 'provisioning'
+    return NextResponse.json(
+      {
+        status,
+        provisioned: status === 'active',
+        network: process.env.STELLAR_NETWORK ?? 'testnet',
+      },
+      {
+        headers: { 'Cache-Control': 'no-store, max-age=0' },
+      },
+    )
+  } catch (error) {
+    console.error('[seyf][wallet-status] db_error', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/docs/sql/user_wallets.sql
+++ b/docs/sql/user_wallets.sql
@@ -1,0 +1,14 @@
+create table if not exists user_wallets (
+  id uuid primary key,
+  user_id text not null unique references users(id),
+  pollar_wallet_id text unique,
+  stellar_public_key text unique,
+  status text not null default 'provisioning' check (
+    status in ('provisioning', 'active', 'error')
+  ),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists user_wallets_user_id_idx
+  on user_wallets (user_id);

--- a/lib/seyf/pollar-wallet-provision.ts
+++ b/lib/seyf/pollar-wallet-provision.ts
@@ -1,0 +1,181 @@
+export type ProvisionResult = {
+  pollarWalletId: string
+  stellarPublicKey: string
+  status: 'provisioning' | 'active' | 'error'
+}
+
+type PollarWalletResponse = Record<string, unknown>
+
+type AdminAlertPayload = {
+  event: 'pollar_wallet_provision_failed'
+  userId: string
+  error: string
+  timestamp: string
+}
+
+const RETRY_BACKOFF_MS = [500, 1000, 2000] as const
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+function getPollarApiKeyOrThrow(): string {
+  const apiKey = process.env.POLLAR_API_KEY?.trim()
+  if (!apiKey) {
+    throw new Error('POLLAR_API_KEY is required to provision wallets.')
+  }
+  return apiKey
+}
+
+function getPollarApiBaseUrl(): string {
+  const base = process.env.POLLAR_API_BASE_URL?.trim() || 'https://api.pollar.xyz'
+  return base.endsWith('/') ? base.slice(0, -1) : base
+}
+
+function extractPollarWalletId(payload: PollarWalletResponse): string | null {
+  const direct =
+    payload.walletId ??
+    payload.wallet_id ??
+    payload.pollarWalletId ??
+    payload.pollar_wallet_id ??
+    payload.id
+  if (typeof direct === 'string' && direct.trim()) return direct.trim()
+
+  const data = payload.data
+  if (data && typeof data === 'object') {
+    const nested = data as Record<string, unknown>
+    const value =
+      nested.walletId ??
+      nested.wallet_id ??
+      nested.pollarWalletId ??
+      nested.pollar_wallet_id ??
+      nested.id
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+
+  return null
+}
+
+function extractStellarPublicKey(payload: PollarWalletResponse): string | null {
+  const direct =
+    payload.stellarPublicKey ??
+    payload.stellar_public_key ??
+    payload.publicKey ??
+    payload.public_key ??
+    payload.stellarAddress ??
+    payload.stellar_address
+  if (typeof direct === 'string' && direct.trim()) return direct.trim()
+
+  const data = payload.data
+  if (data && typeof data === 'object') {
+    const nested = data as Record<string, unknown>
+    const value =
+      nested.stellarPublicKey ??
+      nested.stellar_public_key ??
+      nested.publicKey ??
+      nested.public_key ??
+      nested.stellarAddress ??
+      nested.stellar_address
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+
+  return null
+}
+
+async function sendAdminAlert(payload: AdminAlertPayload): Promise<void> {
+  console.error(JSON.stringify(payload))
+
+  const webhook = process.env.ADMIN_ALERT_WEBHOOK_URL?.trim()
+  if (!webhook) return
+
+  try {
+    await fetch(webhook, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+  } catch {
+    // Do not mask original provisioning failure.
+  }
+}
+
+async function createPollarWallet(userId: string, apiKey: string): Promise<ProvisionResult> {
+  const network = process.env.STELLAR_NETWORK ?? 'testnet'
+  const baseUrl = getPollarApiBaseUrl()
+
+  const response = await fetch(`${baseUrl}/wallets`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      external_id: userId,
+      network,
+      custody: 'embedded',
+    }),
+  })
+
+  const text = await response.text()
+  if (!response.ok) {
+    throw new Error(`Pollar wallet provisioning failed (${response.status}): ${text.slice(0, 300)}`)
+  }
+
+  let parsed: PollarWalletResponse
+  try {
+    parsed = text ? (JSON.parse(text) as PollarWalletResponse) : {}
+  } catch {
+    throw new Error('Pollar wallet provisioning returned invalid JSON.')
+  }
+
+  const pollarWalletId = extractPollarWalletId(parsed)
+  const stellarPublicKey = extractStellarPublicKey(parsed)
+  if (!pollarWalletId || !stellarPublicKey) {
+    throw new Error('Pollar wallet provisioning response is missing wallet identifiers.')
+  }
+
+  return {
+    pollarWalletId,
+    stellarPublicKey,
+    status: 'active',
+  }
+}
+
+export async function provisionWalletForUser(userId: string): Promise<ProvisionResult> {
+  const apiKey = getPollarApiKeyOrThrow()
+
+  try {
+    return await createPollarWallet(userId, apiKey)
+  } catch (firstError) {
+    let lastError = firstError
+
+    for (const delayMs of RETRY_BACKOFF_MS) {
+      await sleep(delayMs)
+      try {
+        return await createPollarWallet(userId, apiKey)
+      } catch (retryError) {
+        lastError = retryError
+      }
+    }
+
+    const alertPayload: AdminAlertPayload = {
+      event: 'pollar_wallet_provision_failed',
+      userId,
+      error: lastError instanceof Error ? lastError.message : String(lastError),
+      timestamp: new Date().toISOString(),
+    }
+    await sendAdminAlert(alertPayload)
+
+    return {
+      pollarWalletId: '',
+      stellarPublicKey: '',
+      status: 'error',
+    }
+  }
+}
+
+export function isWalletActive(row: { status: string } | null | undefined): boolean {
+  return row?.status === 'active'
+}

--- a/lib/seyf/user-wallets.ts
+++ b/lib/seyf/user-wallets.ts
@@ -1,0 +1,107 @@
+import { randomUUID } from 'node:crypto'
+import { mkdir, readFile, writeFile } from 'fs/promises'
+import path from 'path'
+import type { ProvisionResult } from '@/lib/seyf/pollar-wallet-provision'
+
+export type UserWalletStatus = 'provisioning' | 'active' | 'error'
+
+export type UserWalletRow = {
+  id: string
+  userId: string
+  pollarWalletId: string | null
+  stellarPublicKey: string | null
+  status: UserWalletStatus
+  createdAt: string
+  updatedAt: string
+}
+
+type UserWalletStore = {
+  rows: UserWalletRow[]
+}
+
+function userWalletsPath() {
+  return path.join(process.cwd(), 'data', 'seyf-user-wallets.json')
+}
+
+async function loadUserWallets(): Promise<UserWalletStore> {
+  try {
+    const raw = await readFile(userWalletsPath(), 'utf-8')
+    const parsed = JSON.parse(raw) as UserWalletStore
+    if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.rows)) {
+      return { rows: [] }
+    }
+    return parsed
+  } catch {
+    return { rows: [] }
+  }
+}
+
+async function saveUserWallets(store: UserWalletStore): Promise<void> {
+  await mkdir(path.dirname(userWalletsPath()), { recursive: true })
+  await writeFile(userWalletsPath(), JSON.stringify(store, null, 2), 'utf-8')
+}
+
+export async function getUserWalletByUserId(userId: string): Promise<UserWalletRow | null> {
+  const store = await loadUserWallets()
+  const found = store.rows.find((row) => row.userId === userId)
+  return found ?? null
+}
+
+/**
+ * Idempotente: equivalente a INSERT ... ON CONFLICT (user_id) DO NOTHING.
+ */
+export async function insertProvisioningWalletRow(userId: string): Promise<UserWalletRow> {
+  const store = await loadUserWallets()
+  const existing = store.rows.find((row) => row.userId === userId)
+  if (existing) return existing
+
+  const now = new Date().toISOString()
+  const row: UserWalletRow = {
+    id: randomUUID(),
+    userId,
+    pollarWalletId: null,
+    stellarPublicKey: null,
+    status: 'provisioning',
+    createdAt: now,
+    updatedAt: now,
+  }
+  store.rows.unshift(row)
+  await saveUserWallets(store)
+  return row
+}
+
+export async function updateUserWalletFromProvisionResult(
+  userId: string,
+  result: ProvisionResult,
+): Promise<UserWalletRow> {
+  const store = await loadUserWallets()
+  const now = new Date().toISOString()
+  const index = store.rows.findIndex((row) => row.userId === userId)
+
+  if (index === -1) {
+    const created: UserWalletRow = {
+      id: randomUUID(),
+      userId,
+      pollarWalletId: result.pollarWalletId || null,
+      stellarPublicKey: result.stellarPublicKey || null,
+      status: result.status,
+      createdAt: now,
+      updatedAt: now,
+    }
+    store.rows.unshift(created)
+    await saveUserWallets(store)
+    return created
+  }
+
+  const current = store.rows[index]
+  const next: UserWalletRow = {
+    ...current,
+    pollarWalletId: result.pollarWalletId || null,
+    stellarPublicKey: result.stellarPublicKey || null,
+    status: result.status,
+    updatedAt: now,
+  }
+  store.rows[index] = next
+  await saveUserWallets(store)
+  return next
+}

--- a/lib/seyf/wallet-provisioning.ts
+++ b/lib/seyf/wallet-provisioning.ts
@@ -1,0 +1,33 @@
+import { isWalletActive, provisionWalletForUser } from '@/lib/seyf/pollar-wallet-provision'
+import {
+  getUserWalletByUserId,
+  insertProvisioningWalletRow,
+  updateUserWalletFromProvisionResult,
+} from '@/lib/seyf/user-wallets'
+
+export async function triggerWalletProvisioningForUser(userId: string): Promise<void> {
+  await insertProvisioningWalletRow(userId)
+  const provisioned = await provisionWalletForUser(userId)
+  const row = await updateUserWalletFromProvisionResult(userId, provisioned)
+
+  if (provisioned.status === 'active') {
+    console.info('[seyf][wallet-provisioning] wallet_active', {
+      userId,
+      status: row.status,
+    })
+    return
+  }
+
+  console.error('[seyf][wallet-provisioning] wallet_error', {
+    userId,
+    status: row.status,
+  })
+}
+
+export async function assertWalletActiveForUser(userId: string): Promise<void> {
+  const row = await getUserWalletByUserId(userId)
+  if (isWalletActive(row)) return
+  throw new Error(
+    'Wallet provisioning is still pending. The first deposit cannot proceed until provisioning completes.',
+  )
+}


### PR DESCRIPTION
- lib/seyf/pollar-wallet-provision.ts: server-side Pollar client, 3-attempt exponential-backoff retry, admin alert on exhaustion
- app/api/seyf/wallet/status/route.ts: GET /api/seyf/wallet/status
- app/(app)/identidad/actions.ts: triggerWalletProvisioning + assertWalletActive
- DB migration: user_wallets table (no private key/seed columns)
- Tests: pollar-wallet-provision.test.ts (mocked HTTP)

Closes #25