### PR TITLE
feat(advance): implement interactive simulator and native confirmation sheet

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -125,3 +125,41 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* advance simulator */
+dialog.adv-sheet {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  top: auto;
+  width: 100%;
+  max-width: 100%;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  outline: none;
+  transform: translateY(100%);
+  transition: transform 0.3s cubic-bezier(0.32, 0.72, 0, 1);
+}
+dialog.adv-sheet[open] {
+  transform: translateY(0);
+}
+dialog.adv-sheet[open].adv-sheet-exit {
+  transform: translateY(100%);
+  transition: transform 0.28s cubic-bezier(0.4, 0, 1, 1);
+}
+dialog.adv-sheet::backdrop {
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(2px);
+}
+@keyframes adv-stroke {
+  from { stroke-dashoffset: 60; }
+  to   { stroke-dashoffset: 0; }
+}
+.adv-check {
+  stroke-dasharray: 60;
+  stroke-dashoffset: 60;
+  animation: adv-stroke 0.55s ease-out 0.1s forwards;
+}

--- a/components/app/advance-simulator.tsx
+++ b/components/app/advance-simulator.tsx
@@ -1,0 +1,366 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { formatMXN } from '@/lib/formatters'
+
+export type AdvanceSimulationData = {
+  advance_available: boolean
+  max_advance_mxn: number
+  fee_mxn: number
+  net_to_user_mxn: number
+  cycle_end_date: string
+  years_selected?: number
+  error?: string
+}
+
+export type AdvanceSimulatorProps = {
+  simulation: AdvanceSimulationData
+  advanceUsed: boolean
+}
+
+const PRESET_STEPS = [0.25, 0.5, 0.75, 1.0] as const
+type PresetStep = (typeof PRESET_STEPS)[number]
+type SheetState = 'idle' | 'confirming' | 'success' | 'error'
+
+export function AdvanceSimulator({ simulation, advanceUsed }: AdvanceSimulatorProps) {
+  const maxAdvance = simulation.max_advance_mxn
+  const flatFee = simulation.fee_mxn
+
+  const [amount, setAmount] = useState<number>(maxAdvance)
+  const [sheetState, setSheetState] = useState<SheetState>('idle')
+  const [sheetError, setSheetError] = useState<string | null>(null)
+  const dialogRef = useRef<HTMLDialogElement>(null)
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current !== null) clearTimeout(closeTimerRef.current)
+    }
+  }, [])
+
+  const receive = Math.max(0, amount - flatFee)
+  const belowMin = amount > 0 && amount < 100
+  const belowFee = amount >= 100 && amount <= flatFee
+  const canConfirm = amount > flatFee && amount >= 100
+  const yearsSelected = simulation.years_selected ?? 1
+
+  const cycleDate = new Date(simulation.cycle_end_date).toLocaleDateString('es-MX', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  })
+
+  const activePreset: PresetStep | null =
+    PRESET_STEPS.find((f) => Math.abs(maxAdvance * f - amount) < 0.02) ?? null
+
+  function setAmountClamped(raw: number) {
+    const safe = isNaN(raw) ? 0 : raw
+    setAmount(Math.round(Math.min(Math.max(0, safe), maxAdvance) * 100) / 100)
+  }
+
+  function handlePreset(fraction: PresetStep) {
+    setAmount(Math.round(maxAdvance * fraction * 100) / 100)
+  }
+
+  function openSheet() {
+    setSheetState('idle')
+    setSheetError(null)
+    dialogRef.current?.showModal()
+  }
+
+  function closeSheet() {
+    const dialog = dialogRef.current
+    if (!dialog) return
+    dialog.classList.add('adv-sheet-exit')
+    closeTimerRef.current = setTimeout(() => {
+      closeTimerRef.current = null
+      dialog.classList.remove('adv-sheet-exit')
+      dialog.close()
+    }, 280)
+  }
+
+  function handleDialogClose() {
+    setSheetState('idle')
+    setSheetError(null)
+  }
+
+  async function handleConfirm() {
+    setSheetState('confirming')
+    setSheetError(null)
+    try {
+      const res = await fetch('/api/seyf/advance/confirm', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ amount_mxn: amount, years: yearsSelected }),
+      })
+      const data = (await res.json().catch(() => ({}))) as {
+        status?: string
+        error?: { message_es?: string } | string
+        message_es?: string
+      }
+      if (!res.ok) {
+        const msg =
+          typeof data.error === 'object'
+            ? (data.error?.message_es ?? 'Error al procesar el adelanto.')
+            : (data.error ?? data.message_es ?? `Error HTTP ${res.status}`)
+        throw new Error(msg)
+      }
+      setSheetState('success')
+    } catch (e) {
+      setSheetError(e instanceof Error ? e.message : 'Error de conexión. Intenta nuevamente.')
+      setSheetState('error')
+    }
+  }
+
+  if (advanceUsed) {
+    return (
+      <div className="rounded-[1.5rem] border border-amber-500/25 bg-amber-500/10 p-6 text-center">
+        <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-amber-100/60 dark:bg-amber-900/30">
+          <svg
+            width="22"
+            height="22"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="text-amber-500"
+            aria-hidden="true"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <path d="M12 8v4M12 16h.01" />
+          </svg>
+        </div>
+        <p className="font-bold text-foreground">Ciclo completado</p>
+        <p className="mt-1.5 text-sm text-muted-foreground">
+          Ya usaste tu adelanto de este ciclo. Disponible de nuevo el{' '}
+          <strong className="text-foreground">{cycleDate}</strong>.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <section className="space-y-5 rounded-[1.5rem] bg-card p-6 shadow-[0_8px_28px_rgba(0,0,0,0.14)]">
+        {/* Numeric input */}
+        <div>
+          <label
+            htmlFor="adv-amount"
+            className="text-xs font-medium uppercase tracking-wider text-muted-foreground"
+          >
+            Monto a adelantar
+          </label>
+          <div className="mt-2 flex items-center gap-2 rounded-xl border border-border bg-secondary/30 px-4 py-3 focus-within:ring-2 focus-within:ring-ring">
+            <span className="text-lg font-bold text-muted-foreground" aria-hidden="true">
+              $
+            </span>
+            <input
+              id="adv-amount"
+              type="number"
+              min={0}
+              max={maxAdvance}
+              step={1}
+              value={amount}
+              onChange={(e) => setAmountClamped(parseFloat(e.target.value))}
+              className="w-full bg-transparent text-2xl font-black tabular-nums text-foreground outline-none"
+            />
+            <span className="shrink-0 text-xs font-bold text-muted-foreground">MXN</span>
+          </div>
+
+          {belowMin && (
+            <p role="alert" className="mt-1.5 text-xs font-semibold text-destructive">
+              El monto mínimo es $100
+            </p>
+          )}
+          {belowFee && (
+            <p role="alert" className="mt-1.5 text-xs font-semibold text-destructive">
+              El monto seleccionado debe superar la comisión ({formatMXN(flatFee)})
+            </p>
+          )}
+        </div>
+
+        {/* Range slider + preset snaps */}
+        <div>
+          <input
+            type="range"
+            min={0}
+            max={maxAdvance}
+            step={maxAdvance > 0 ? maxAdvance / 400 : 1}
+            value={amount}
+            onChange={(e) => setAmountClamped(parseFloat(e.target.value))}
+            className="w-full rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            aria-label="Desliza para elegir el monto"
+          />
+          <div className="mt-2 flex gap-2">
+            {PRESET_STEPS.map((f) => (
+              <button
+                key={f}
+                type="button"
+                onClick={() => handlePreset(f)}
+                aria-pressed={activePreset === f}
+                className={[
+                  'flex-1 rounded-full border py-1.5 text-xs font-semibold transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                  activePreset === f
+                    ? 'border-primary bg-primary text-primary-foreground'
+                    : 'border-border bg-secondary text-muted-foreground hover:bg-secondary/80',
+                ].join(' ')}
+              >
+                {f * 100}%
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Real-time breakdown */}
+        <div className="space-y-2 rounded-xl border border-border bg-secondary/40 px-4 py-3.5">
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground">Recibes hoy</span>
+            <span className="font-bold tabular-nums text-foreground">{formatMXN(receive)}</span>
+          </div>
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground">Comisión Seyf</span>
+            <span className="tabular-nums text-muted-foreground">{formatMXN(flatFee)}</span>
+          </div>
+          <div className="flex items-center justify-between border-t border-border pt-2 text-sm">
+            <span className="font-semibold text-foreground">Tu principal</span>
+            <span className="font-bold text-[#2e7d69] dark:text-[#7ec8a0]">intacto</span>
+          </div>
+        </div>
+
+        <Button
+          onClick={openSheet}
+          disabled={!canConfirm}
+          className="h-12 w-full rounded-full bg-foreground text-base font-bold text-background shadow-[0_10px_28px_rgba(255,255,255,0.12)] hover:bg-foreground/90 disabled:opacity-60"
+        >
+          Solicitar adelanto
+        </Button>
+      </section>
+
+      {/* Native <dialog> bottom sheet */}
+      <dialog
+        ref={dialogRef}
+        className="adv-sheet"
+        onClose={handleDialogClose}
+        aria-modal="true"
+        aria-labelledby="adv-sheet-title"
+      >
+        <div className="rounded-t-[2rem] border-t border-border bg-card px-6 pb-10 pt-5">
+          <div className="mx-auto mb-5 h-1.5 w-10 rounded-full bg-border" aria-hidden="true" />
+
+          {sheetState === 'success' ? (
+            <div className="flex flex-col items-center py-6 text-center">
+              <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-[#9ec7b3]/35 dark:bg-[#6ba690]/25">
+                <svg
+                  width="32"
+                  height="32"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-label="Operación exitosa"
+                >
+                  <polyline className="adv-check" points="20 6 9 17 4 12" stroke="#2e7d69" />
+                </svg>
+              </div>
+              <p className="text-xl font-black text-foreground">Adelanto listo</p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Tu adelanto está listo. Ya puedes retirarlo a tu banco.
+              </p>
+              <Button onClick={closeSheet} className="mt-6 h-11 w-full rounded-full font-bold">
+                Cerrar
+              </Button>
+            </div>
+          ) : (
+            <>
+              <h2 id="adv-sheet-title" className="text-lg font-black text-foreground">
+                Confirmar adelanto
+              </h2>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                No es un préstamo. No genera deuda. Tu capital sigue trabajando.
+              </p>
+
+              <div className="mt-5 space-y-2 rounded-xl border border-border bg-secondary/40 px-4 py-3.5">
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-muted-foreground">Recibes hoy</span>
+                  <span className="font-bold tabular-nums text-foreground">{formatMXN(receive)}</span>
+                </div>
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-muted-foreground">Comisión Seyf</span>
+                  <span className="tabular-nums text-muted-foreground">{formatMXN(flatFee)}</span>
+                </div>
+                <div className="flex items-center justify-between border-t border-border pt-2 text-sm">
+                  <span className="font-semibold text-foreground">Tu principal</span>
+                  <span className="font-bold text-[#2e7d69] dark:text-[#7ec8a0]">intacto</span>
+                </div>
+              </div>
+
+              {sheetState === 'error' && sheetError !== null && (
+                <div className="mt-4 rounded-xl border border-destructive/30 bg-destructive/10 px-4 py-3">
+                  <p className="text-sm text-destructive">{sheetError}</p>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setSheetState('idle')
+                      setSheetError(null)
+                    }}
+                    className="mt-2 rounded text-xs font-semibold text-destructive underline outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    Reintentar
+                  </button>
+                </div>
+              )}
+
+              <div className="mt-5 space-y-3">
+                <Button
+                  onClick={handleConfirm}
+                  disabled={sheetState === 'confirming'}
+                  className="h-12 w-full rounded-full font-bold disabled:opacity-60"
+                >
+                  {sheetState === 'confirming' ? (
+                    <span className="flex items-center gap-2">
+                      <svg
+                        className="h-4 w-4 animate-spin"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        aria-hidden="true"
+                      >
+                        <circle
+                          className="opacity-25"
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke="currentColor"
+                          strokeWidth="4"
+                        />
+                        <path
+                          className="opacity-75"
+                          fill="currentColor"
+                          d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+                        />
+                      </svg>
+                      Procesando...
+                    </span>
+                  ) : (
+                    'Confirmar'
+                  )}
+                </Button>
+                <button
+                  type="button"
+                  onClick={closeSheet}
+                  disabled={sheetState === 'confirming'}
+                  className="w-full rounded-xl py-2 text-sm font-semibold text-muted-foreground transition hover:text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-40"
+                >
+                  Cancelar
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </dialog>
+    </>
+  )
+}

--- a/components/app/dashboard-client.tsx
+++ b/components/app/dashboard-client.tsx
@@ -23,9 +23,7 @@ import { MovementDetailSheet } from "@/components/app/movement-detail-sheet";
 import { YieldTrendChart } from "@/components/app/yield-trend-chart";
 import { iconForMovimientoTipo } from "@/components/app/movement-tipo-icons";
 import { Button } from "@/components/ui/button";
-import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/ui/empty-state";
-import { useTranslations } from "next-intl";
 import { balanceForAssetCode } from "@/lib/seyf/accesly-balances";
 import { cetesBalanceEquivMxne } from "@/lib/seyf/cetes-mxne-equiv";
 import { cetesStablebondDisplayFromRow } from "@/lib/seyf/stablebond-cetes-display";
@@ -1112,10 +1110,10 @@ export default function DashboardClient({ vm }: { vm: DashboardViewModel }) {
                 </div>
               ))}
             </div>
-            {effectiveAdelantableMxn > 0 ? (
+            {effectiveAdelantableMxn > 0 || effectiveAdvanceUsed ? (
               <Link href="/adelanto" className="mt-4 block">
                 <Button className="h-12 w-full rounded-full text-base font-black">
-                  Pedir adelanto
+                  {effectiveAdvanceUsed ? 'Ver mi adelanto' : 'Pedir adelanto'}
                 </Button>
               </Link>
             ) : (


### PR DESCRIPTION
## Description
Closes #42. Implements the complete interactive advance simulator workspace under `/adelanto` and hardens the transaction confirmation lifecycle. 

### Core Changes
* **`components/app/advance-simulator.tsx` (100% New):**
  * Established bi-directional state synchronization between the explicit text input and the custom native `<input type="range">` element.
  * Added snapping mechanics for 25% / 50% / 75% / 100% presets.
  * Integrated real-time fee breakdown using the shared `formatMXN` framework.
  * Implemented inline constraint checks for minimum floor limits ($100 MXN) and fee sub-zero boundaries.
  * Built a zero-dependency confirmation bottom sheet leveraging the native HTML5 `<dialog>` element driven by hardware-accelerated CSS translation vectors.
  * Wired loading micro-states (spinners/input disabling), inline error retry mechanisms, and a performance-optimized SVG checkmark utilizing a `stroke-dashoffset` transition.

* **`app/(app)/adelanto/page.tsx` (Complete Rewrite):**
  * Consolidated legacy monolithic layers (472 lines) down to a lean asynchronous shell (161 lines).
  * Wired concurrent data resolution for `/api/seyf/advance/simulate` and `/api/seyf/advance/list` to handle status mappings through strict type guards.
  * Introduced fallback fixture boundaries to prevent runtime breaks against incomplete peer backend endpoints (#21, #33).

* **`components/app/dashboard-client.tsx` (Patch):**
  * Extended conditional visibility paths to correctly redirect users to the locked cycle layout when an active advance balance is already flagged.

### Production Standards Hardening
* Extracted temporary local formats to use the project's shared `lib/formatters.ts`.
* Removed redundant input attributes to guarantee compliance with WCAG 2.5.3 semantic layouts.
* Protected against stale reference memory leaks by clear-tracking active macro task timers on component destruction lifecycles.
* Migrated dialog layouts into `app/globals.css`.

---

## Visual Evidence

### 1.  Native Bottom Sheet Confirmation Overlay
<img width="1920" height="988" alt="Captura de pantalla_20260623_142233" src="https://github.com/user-attachments/assets/f6d70d02-63d4-4f67-936f-01eea908824c" />


Any feedback is welcome, thanks!! 
