### PR TITLE
feat(onboarding): add multi-step registration and empty states

### DIFF
--- a/app/(app)/historial/historial-page-client.tsx
+++ b/app/(app)/historial/historial-page-client.tsx
@@ -11,8 +11,6 @@ import { MovementDetailSheet } from "@/components/app/movement-detail-sheet";
 import { iconForMovimientoTipo } from "@/components/app/movement-tipo-icons";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
-import { Skeleton } from "@/components/ui/skeleton";
-import { useTranslations } from "next-intl";
 import {
   HISTORIAL_POLL_EXTRA_DELAYS_MS,
   HISTORIAL_POLL_MS,

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -2,10 +2,12 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
 export default function LoginPage() {
+  const t = useTranslations("auth.login");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
@@ -18,6 +20,7 @@ export default function LoginPage() {
 
   return (
     <div className="flex min-h-screen flex-col bg-background px-6 py-12">
+      <div className="mx-auto w-full max-w-md">
       {/* Header */}
       <div className="mb-12">
         <h1 className="text-4xl font-black tracking-tight text-foreground">
@@ -28,9 +31,7 @@ export default function LoginPage() {
       <div className="flex flex-1 flex-col justify-center">
         <div className="mb-10">
           <h2 className="text-4xl font-black tracking-tight text-foreground leading-none">
-            Bienvenido
-            <br />
-            de vuelta.
+            Bienvenido de vuelta.
           </h2>
           <p className="mt-4 text-base text-muted-foreground font-normal">
             Inicia sesión para ver tu ahorro y rendimientos.
@@ -69,23 +70,24 @@ export default function LoginPage() {
 
         <p className="mt-6 text-center text-sm text-muted-foreground">
           <Link
-            href="#"
+            href="/recuperar"
             className="underline underline-offset-4 hover:text-foreground"
           >
-            Olvide mi contrasena
+            {t("forgotPassword")}
           </Link>
         </p>
       </div>
 
-      <p className="mt-8 text-center text-sm text-muted-foreground">
-        No tienes cuenta?{" "}
-        <Link
-          href="/registro"
-          className="font-bold text-foreground hover:underline"
-        >
-          Crear cuenta
-        </Link>
-      </p>
+        <p className="mt-8 text-center text-sm text-muted-foreground">
+          No tienes cuenta?{" "}
+          <Link
+            href="/registro"
+            className="font-bold text-foreground hover:underline"
+          >
+            Crear cuenta
+          </Link>
+        </p>
+      </div>
     </div>
   );
 }

--- a/app/registro/page.tsx
+++ b/app/registro/page.tsx
@@ -1,144 +1,131 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useTranslations } from "next-intl";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { ProgressIndicator } from "@/components/app/registration-steps/progress-indicator";
+import { AccountStep } from "@/components/app/registration-steps/account-step";
+import { BusinessStep } from "@/components/app/registration-steps/business-step";
+import { PhoneVerificationStep } from "@/components/app/registration-steps/phone-verification-step";
+import { SuccessConfirmation } from "@/components/app/registration-steps/success-confirmation";
 
 export default function RegistroPage() {
-  const t = useTranslations("auth.registro");
-  const router = useRouter();
-  const [form, setForm] = useState({
-    nombre: "",
-    correo: "",
-    telefono: "",
-    password: "",
-  });
-  const [accepted, setAccepted] = useState(false);
-  const [loading, setLoading] = useState(false);
+  const [step, setStep] = useState(0);
+  const [phone, setPhone] = useState("");
+  const prevStep = useRef(0);
 
-  const handleChange =
-    (field: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
-      setForm((prev) => ({ ...prev, [field]: e.target.value }));
-    };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!accepted) return;
-    setLoading(true);
-    setTimeout(() => {
-      setLoading(false);
-      router.push("/identidad");
-    }, 1200);
-  };
+  const goingForward = step >= prevStep.current;
+  prevStep.current = step;
 
   return (
     <div className="flex min-h-screen flex-col bg-background px-6 py-12">
-      {/* Header */}
-      <div className="mb-10">
-        <Link
-          href="/"
-          className="text-2xl font-black tracking-tight text-foreground"
-        >
-          Seyf
-        </Link>
-      </div>
+      <style>{`
+        @keyframes slideInFromRight {
+          from { opacity: 0; transform: translateX(30px); }
+          to   { opacity: 1; transform: translateX(0); }
+        }
+        @keyframes slideInFromLeft {
+          from { opacity: 0; transform: translateX(-30px); }
+          to   { opacity: 1; transform: translateX(0); }
+        }
+        .slide-forward {
+          animation: slideInFromRight 0.35s cubic-bezier(0.16, 1, 0.3, 1);
+        }
+        .slide-backward {
+          animation: slideInFromLeft 0.35s cubic-bezier(0.16, 1, 0.3, 1);
+        }
+      `}</style>
 
-      <div className="flex flex-1 flex-col justify-center">
-        <div className="mb-8">
-          <h2 className="text-4xl font-black tracking-tight text-foreground leading-none">
-            Crea tu
-            <br />
-            cuenta.
-          </h2>
-          <p className="mt-4 text-base text-muted-foreground font-normal">
-            {t('subtitle')}
-          </p>
+      <div className="mx-auto w-full max-w-md">
+        <div className="mb-12">
+          <h1 className="text-4xl font-black tracking-tight text-foreground">
+            Seyf
+          </h1>
         </div>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <Input
-            type="text"
-            placeholder={t('namePlaceholder')}
-            value={form.nombre}
-            onChange={handleChange("nombre")}
-            required
-            className="h-14 rounded-full bg-secondary px-6 text-base font-medium placeholder:text-muted-foreground border-0 focus-visible:ring-1 focus-visible:ring-foreground"
-          />
-          <Input
-            type="email"
-            placeholder="Correo electrónico"
-            value={form.correo}
-            onChange={handleChange("correo")}
-            required
-            className="h-14 rounded-full bg-secondary px-6 text-base font-medium placeholder:text-muted-foreground border-0 focus-visible:ring-1 focus-visible:ring-foreground"
-          />
-          <Input
-            type="tel"
-            placeholder="Teléfono (10 dígitos)"
-            value={form.telefono}
-            onChange={handleChange("telefono")}
-            required
-            maxLength={10}
-            className="h-14 rounded-full bg-secondary px-6 text-base font-medium placeholder:text-muted-foreground border-0 focus-visible:ring-1 focus-visible:ring-foreground"
-          />
-          <Input
-            type="password"
-            placeholder="Contraseña"
-            value={form.password}
-            onChange={handleChange("password")}
-            required
-            className="h-14 rounded-full bg-secondary px-6 text-base font-medium placeholder:text-muted-foreground border-0 focus-visible:ring-1 focus-visible:ring-foreground"
-          />
-
-          {/* Terms checkbox */}
-          <label className="flex items-start gap-3 cursor-pointer pt-2">
-            <div
-              onClick={() => setAccepted(!accepted)}
-              className={`mt-0.5 h-5 w-5 shrink-0 rounded-full border transition-colors cursor-pointer ${accepted ? "bg-foreground border-foreground" : "border-muted-foreground"}`}
-            />
-            <span className="text-sm text-muted-foreground leading-relaxed">
-              Acepto los{" "}
-              <Link
-                href="#"
-                className="text-foreground underline underline-offset-4"
-              >
-                Términos y Condiciones
-              </Link>{" "}
-              y el{" "}
-              <Link
-                href="#"
-                className="text-foreground underline underline-offset-4"
-              >
-                Aviso de Privacidad
-              </Link>
-            </span>
-          </label>
-
-          <div className="pt-2">
-            <Button
-              type="submit"
-              size="lg"
-              disabled={loading || !accepted}
-              className="w-full h-14 rounded-full bg-foreground text-background font-bold text-base hover:bg-foreground/90 transition-all disabled:opacity-40"
-            >
-              {loading ? "Creando cuenta..." : "Continuar"}
-            </Button>
+        <div className="flex flex-1 flex-col justify-center">
+          <div className="mb-10">
+            <h2 className="text-4xl font-black tracking-tight text-foreground leading-none">
+              Crea tu cuenta.
+            </h2>
+            <p className="mt-4 text-base text-muted-foreground font-normal">
+              Tu dinero, siempre disponible.
+            </p>
           </div>
-        </form>
-      </div>
 
-      <p className="mt-8 text-center text-sm text-muted-foreground">
-        Ya tienes cuenta?{" "}
-        <Link
-          href="/login"
-          className="font-bold text-foreground hover:underline"
-        >
-          Iniciar sesión
-        </Link>
-      </p>
+          {step < 3 && <ProgressIndicator current={step} />}
+
+          <div
+            key={step}
+            className={`w-full ${goingForward ? "slide-forward" : "slide-backward"}`}
+          >
+            {step === 0 && (
+              <>
+                <h2 className="text-4xl font-black tracking-tight text-foreground leading-none">
+                  Tu cuenta
+                </h2>
+                <p className="mt-4 mb-8 text-base text-muted-foreground">
+                  Ingresa tus datos personales para empezar.
+                </p>
+                <AccountStep
+                  defaultValues={{ nombre: "", correo: "", password: "" }}
+                  onNext={() => setStep(1)}
+                />
+              </>
+            )}
+
+            {step === 1 && (
+              <>
+                <h2 className="text-4xl font-black tracking-tight text-foreground leading-none">
+                  Tu negocio
+                </h2>
+                <p className="mt-4 mb-8 text-base text-muted-foreground">
+                  Información de tu empresa o actividad profesional.
+                </p>
+                <BusinessStep
+                  defaultValues={{ businessName: "", rfc: "", curp: "" }}
+                  onNext={() => setStep(2)}
+                  onBack={() => setStep(0)}
+                />
+              </>
+            )}
+
+            {step === 2 && (
+              <>
+                <h2 className="text-4xl font-black tracking-tight text-foreground leading-none">
+                  Verifica tu teléfono
+                </h2>
+                <p className="mt-4 mb-8 text-base text-muted-foreground">
+                  Ingresa tu número para recibir un código de verificación.
+                </p>
+                <PhoneVerificationStep
+                  defaultValues={{ phone, otp: "" }}
+                  onComplete={(data) => {
+                    setPhone(data.phone);
+                    setStep(3);
+                  }}
+                  onBack={() => setStep(1)}
+                />
+              </>
+            )}
+
+            {step === 3 && (
+              <SuccessConfirmation
+                onResendOtp={() => setStep(2)}
+              />
+            )}
+          </div>
+        </div>
+
+        <p className="mt-8 text-center text-sm text-muted-foreground">
+          Ya tienes cuenta?{" "}
+          <Link
+            href="/login"
+            className="font-bold text-foreground hover:underline"
+          >
+            Iniciar sesión
+          </Link>
+        </p>
+      </div>
     </div>
   );
 }

--- a/components/app/dashboard-client.tsx
+++ b/components/app/dashboard-client.tsx
@@ -23,9 +23,7 @@ import { MovementDetailSheet } from "@/components/app/movement-detail-sheet";
 import { YieldTrendChart } from "@/components/app/yield-trend-chart";
 import { iconForMovimientoTipo } from "@/components/app/movement-tipo-icons";
 import { Button } from "@/components/ui/button";
-import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/ui/empty-state";
-import { useTranslations } from "next-intl";
 import { balanceForAssetCode } from "@/lib/seyf/accesly-balances";
 import { cetesBalanceEquivMxne } from "@/lib/seyf/cetes-mxne-equiv";
 import { cetesStablebondDisplayFromRow } from "@/lib/seyf/stablebond-cetes-display";
@@ -513,25 +511,6 @@ export default function DashboardClient({ vm }: { vm: DashboardViewModel }) {
         <Skeleton className="h-[22rem] rounded-[1.75rem] border border-border" />
         <Skeleton className="h-48 rounded-[1.5rem] border border-border" />
         <Skeleton className="h-40 rounded-[1.5rem] border border-border" />
-      </AppPageBody>
-    );
-  }
-
-  if (!wallet) {
-    return (
-      <AppPageBody className="space-y-4 pt-4">
-        <div className="rounded-[1.5rem] border border-border bg-card px-5 py-8 text-center">
-          <p className="text-sm font-bold text-foreground">{t('connectWallet')}</p>
-          <p className="mt-2 text-xs text-muted-foreground">
-            {t('connectWalletBody')}
-          </p>
-          <Button
-            asChild
-            className="mt-6 h-11 w-full max-w-xs rounded-full font-bold"
-          >
-            <Link href="/">Ir a conectar</Link>
-          </Button>
-        </div>
       </AppPageBody>
     );
   }
@@ -1135,12 +1114,12 @@ export default function DashboardClient({ vm }: { vm: DashboardViewModel }) {
         <section className="relative overflow-hidden rounded-[1.6rem] border border-border bg-card p-5">
           <EmptyState
             variant="compact"
-            illustration="cycle"
-            title="Tu capital está listo para empezar a trabajar"
-            description="Abre tu primer ciclo de rendimiento en pesos invirtiendo en CETES de manera segura."
+            illustration="balance"
+            title={t('emptyStateTitle')}
+            description={t('emptyStateBody')}
             primaryAction={{
-              label: "Agregar fondos",
-              href: "/anadir",
+              label: t('emptyStateCta'),
+              href: "/depositar",
             }}
           />
         </section>

--- a/components/app/registration-steps/account-step.tsx
+++ b/components/app/registration-steps/account-step.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { useTranslations } from "next-intl";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+const formSchema = z.object({
+  nombre: z.string().min(2, "nameMin"),
+  correo: z.string().email("emailInvalid"),
+  password: z
+    .string()
+    .min(8, "passwordMin")
+    .regex(/[A-Z]/, "passwordUppercase")
+    .regex(/[a-z]/, "passwordLowercase")
+    .regex(/[0-9]/, "passwordNumber")
+    .regex(/[^A-Za-z0-9]/, "passwordSpecial"),
+});
+
+export type AccountStepData = z.infer<typeof formSchema>;
+
+interface Props {
+  defaultValues: AccountStepData;
+  onNext: (data: AccountStepData) => void;
+}
+
+const PASSWORD_RULES = [
+  { key: "min", test: (v: string) => v.length >= 8 },
+  { key: "uppercase", test: (v: string) => /[A-Z]/.test(v) },
+  { key: "lowercase", test: (v: string) => /[a-z]/.test(v) },
+  { key: "number", test: (v: string) => /[0-9]/.test(v) },
+  { key: "special", test: (v: string) => /[^A-Za-z0-9]/.test(v) },
+] as const;
+
+export function AccountStep({ defaultValues, onNext }: Props) {
+  const t = useTranslations("auth.registroSteps.step1");
+  const v = useTranslations("auth.registroSteps.validation");
+  const a = useTranslations("auth.registroSteps.actions");
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors, isValid },
+  } = useForm<AccountStepData>({
+    resolver: zodResolver(formSchema),
+    mode: "onChange",
+    defaultValues,
+  });
+
+  const passwordValue = watch("password", "");
+
+  const fieldError = (key: keyof typeof formSchema.shape) => {
+    const msg = errors[key]?.message as string | undefined;
+    return msg ? v(msg as any) : undefined;
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onNext)} className="space-y-5">
+      <div>
+        <p className="text-sm font-medium text-muted-foreground mb-1">
+          {t("nameLabel")}
+        </p>
+        <Input
+          {...register("nombre")}
+          placeholder={t("namePlaceholder")}
+          className="h-14 rounded-full bg-secondary px-6 text-base font-medium placeholder:text-muted-foreground border-0 focus-visible:ring-1 focus-visible:ring-foreground"
+        />
+        {fieldError("nombre") && (
+          <p className="mt-1.5 px-2 text-xs text-red-500">
+            {fieldError("nombre")}
+          </p>
+        )}
+      </div>
+
+      <div>
+        <p className="text-sm font-medium text-muted-foreground mb-1">
+          {t("emailLabel")}
+        </p>
+        <Input
+          {...register("correo")}
+          type="email"
+          placeholder={t("emailPlaceholder")}
+          className="h-14 rounded-full bg-secondary px-6 text-base font-medium placeholder:text-muted-foreground border-0 focus-visible:ring-1 focus-visible:ring-foreground"
+        />
+        {fieldError("correo") && (
+          <p className="mt-1.5 px-2 text-xs text-red-500">
+            {fieldError("correo")}
+          </p>
+        )}
+      </div>
+
+      <div>
+        <p className="text-sm font-medium text-muted-foreground mb-1">
+          {t("passwordLabel")}
+        </p>
+        <Input
+          {...register("password")}
+          type="password"
+          placeholder={t("passwordPlaceholder")}
+          className="h-14 rounded-full bg-secondary px-6 text-base font-medium placeholder:text-muted-foreground border-0 focus-visible:ring-1 focus-visible:ring-foreground"
+        />
+        {fieldError("password") && (
+          <p className="mt-1.5 px-2 text-xs text-red-500">
+            {fieldError("password")}
+          </p>
+        )}
+
+        <ul className="mt-3 space-y-1.5 px-2">
+          {PASSWORD_RULES.map((rule) => {
+            const passed = rule.test(passwordValue);
+            return (
+              <li
+                key={rule.key}
+                className={`flex items-center gap-2 text-xs transition-colors ${
+                  passed ? "text-foreground" : "text-muted-foreground"
+                }`}
+              >
+                <span className={`shrink-0 text-xs font-bold ${passed ? "text-foreground" : "text-muted-foreground"}`}>
+                  {passed ? "✓" : "✗"}
+                </span>
+                {v(`password${rule.key.charAt(0).toUpperCase() + rule.key.slice(1)}` as any)}
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+
+      <div className="pt-2">
+        <Button
+          type="submit"
+          size="lg"
+          disabled={!isValid}
+          className="w-full h-14 rounded-full bg-foreground text-background font-bold text-base hover:bg-foreground/90 transition-all disabled:opacity-40"
+        >
+          {a("continue")}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/components/app/registration-steps/business-step.tsx
+++ b/components/app/registration-steps/business-step.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { useTranslations } from "next-intl";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+const formSchema = z.object({
+  businessName: z.string().min(2, "businessNameRequired"),
+  rfc: z
+    .string()
+    .regex(/^[A-Z0-9]{13}$/, "rfcInvalid"),
+  curp: z
+    .string()
+    .regex(/^[A-Z0-9]{18}$/, "curpInvalid"),
+});
+
+export type BusinessStepData = z.infer<typeof formSchema>;
+
+interface Props {
+  defaultValues: BusinessStepData;
+  onNext: (data: BusinessStepData) => void;
+  onBack: () => void;
+}
+
+export function BusinessStep({ defaultValues, onNext, onBack }: Props) {
+  const t = useTranslations("auth.registroSteps.step2");
+  const a = useTranslations("auth.registroSteps.actions");
+  const v = useTranslations("auth.registroSteps.validation");
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm<BusinessStepData>({
+    resolver: zodResolver(formSchema),
+    mode: "onChange",
+    defaultValues,
+  });
+
+  const fieldError = (key: keyof typeof formSchema.shape) => {
+    const msg = errors[key]?.message as string | undefined;
+    return msg ? v(msg as any) : undefined;
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onNext)} className="space-y-5">
+      <div>
+        <p className="text-sm font-medium text-muted-foreground mb-1">
+          {t("businessNameLabel")}
+        </p>
+        <Input
+          {...register("businessName")}
+          placeholder={t("businessNamePlaceholder")}
+          className="h-14 rounded-full bg-secondary px-6 text-base font-medium placeholder:text-muted-foreground border-0 focus-visible:ring-1 focus-visible:ring-foreground"
+        />
+        {fieldError("businessName") && (
+          <p className="mt-1.5 px-2 text-xs text-red-500">
+            {fieldError("businessName")}
+          </p>
+        )}
+      </div>
+
+      <div>
+        <p className="text-sm font-medium text-muted-foreground mb-1">
+          {t("rfcLabel")}
+        </p>
+        <Input
+          {...register("rfc")}
+          placeholder={t("rfcPlaceholder")}
+          className="h-14 rounded-full bg-secondary px-6 text-base font-medium placeholder:text-muted-foreground border-0 focus-visible:ring-1 focus-visible:ring-foreground"
+        />
+        {fieldError("rfc") && (
+          <p className="mt-1.5 px-2 text-xs text-red-500">{fieldError("rfc")}</p>
+        )}
+      </div>
+
+      <div>
+        <p className="text-sm font-medium text-muted-foreground mb-1">
+          {t("curpLabel")}
+        </p>
+        <Input
+          {...register("curp")}
+          placeholder={t("curpPlaceholder")}
+          className="h-14 rounded-full bg-secondary px-6 text-base font-medium placeholder:text-muted-foreground border-0 focus-visible:ring-1 focus-visible:ring-foreground"
+        />
+        {fieldError("curp") && (
+          <p className="mt-1.5 px-2 text-xs text-red-500">{fieldError("curp")}</p>
+        )}
+      </div>
+
+      <div className="flex gap-3 pt-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="lg"
+          onClick={onBack}
+          className="h-14 w-1/3 rounded-full border border-border bg-transparent font-semibold text-foreground hover:bg-secondary"
+        >
+          {a("back")}
+        </Button>
+        <Button
+          type="submit"
+          size="lg"
+          disabled={!isValid}
+          className="h-14 flex-1 rounded-full bg-foreground text-background font-bold text-base hover:bg-foreground/90 transition-all disabled:opacity-40"
+        >
+          {a("continue")}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/components/app/registration-steps/index.ts
+++ b/components/app/registration-steps/index.ts
@@ -1,0 +1,8 @@
+export { ProgressIndicator } from "./progress-indicator";
+export { AccountStep } from "./account-step";
+export type { AccountStepData } from "./account-step";
+export { BusinessStep } from "./business-step";
+export type { BusinessStepData } from "./business-step";
+export { PhoneVerificationStep } from "./phone-verification-step";
+export type { PhoneVerificationData } from "./phone-verification-step";
+export { SuccessConfirmation } from "./success-confirmation";

--- a/components/app/registration-steps/phone-verification-step.tsx
+++ b/components/app/registration-steps/phone-verification-step.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { useTranslations } from "next-intl";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+const phoneSchema = z.string().regex(/^\d{10}$/, "phoneInvalid");
+const otpSchema = z.string().regex(/^\d{6}$/, "otpInvalid");
+
+const formSchema = z.object({
+  phone: phoneSchema,
+  otp: otpSchema,
+});
+
+export type PhoneVerificationData = z.infer<typeof formSchema>;
+
+interface Props {
+  defaultValues: PhoneVerificationData;
+  onComplete: (data: PhoneVerificationData) => void;
+  onBack: () => void;
+}
+
+export function PhoneVerificationStep({
+  defaultValues,
+  onComplete,
+  onBack,
+}: Props) {
+  const t = useTranslations("auth.registroSteps.step3");
+  const a = useTranslations("auth.registroSteps.actions");
+  const v = useTranslations("auth.registroSteps.validation");
+
+  const [otpSent, setOtpSent] = useState(false);
+  const [countdown, setCountdown] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors, isValid },
+  } = useForm<PhoneVerificationData>({
+    resolver: zodResolver(formSchema),
+    mode: "onChange",
+    defaultValues,
+  });
+
+  const phoneValue = watch("phone");
+  const phoneValid = phoneSchema.safeParse(phoneValue).success;
+
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, []);
+
+  const handleSendOtp = () => {
+    setOtpSent(true);
+    setCountdown(30);
+    intervalRef.current = setInterval(() => {
+      setCountdown((prev) => {
+        if (prev <= 1) {
+          if (intervalRef.current) clearInterval(intervalRef.current);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+  };
+
+  const fieldError = (key: keyof typeof formSchema.shape) => {
+    const msg = errors[key]?.message as string | undefined;
+    return msg ? v(msg as any) : undefined;
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onComplete)} className="space-y-5">
+      <div>
+        <p className="text-sm font-medium text-muted-foreground mb-1">
+          {t("phoneLabel")}
+        </p>
+        <Input
+          {...register("phone")}
+          type="tel"
+          maxLength={10}
+          placeholder={t("phonePlaceholder")}
+          className="h-14 rounded-full bg-secondary px-6 text-base font-medium placeholder:text-muted-foreground border-0 focus-visible:ring-1 focus-visible:ring-foreground"
+        />
+        {fieldError("phone") && (
+          <p className="mt-1.5 px-2 text-xs text-red-500">
+            {fieldError("phone")}
+          </p>
+        )}
+      </div>
+
+      {!otpSent ? (
+        <div className="pt-2">
+          <Button
+            type="button"
+            size="lg"
+            onClick={handleSendOtp}
+            disabled={!phoneValid}
+            className="w-full h-14 rounded-full bg-foreground text-background font-bold text-base hover:bg-foreground/90 transition-all disabled:opacity-40"
+          >
+            Enviar código
+          </Button>
+        </div>
+      ) : (
+        <>
+          <div>
+            <p className="text-sm font-medium text-muted-foreground mb-1">
+              {t("otpLabel")}
+            </p>
+            <Input
+              {...register("otp")}
+              type="text"
+              inputMode="numeric"
+              maxLength={6}
+              placeholder={t("otpPlaceholder")}
+              className="h-14 rounded-full bg-secondary px-6 text-base font-medium placeholder:text-muted-foreground border-0 focus-visible:ring-1 focus-visible:ring-foreground text-center tracking-[0.3em]"
+            />
+            {fieldError("otp") && (
+              <p className="mt-1.5 px-2 text-xs text-red-500">
+                {fieldError("otp")}
+              </p>
+            )}
+          </div>
+
+          <div className="flex items-center justify-between">
+            {countdown > 0 ? (
+              <span className="text-xs text-muted-foreground">
+                Reenviar en {countdown}s
+              </span>
+            ) : (
+              <button
+                type="button"
+                onClick={handleSendOtp}
+                className="text-xs font-semibold text-foreground hover:underline underline-offset-4"
+              >
+                {t("resend")}
+              </button>
+            )}
+            <span className="text-xs text-muted-foreground">
+              {t("sent")}
+            </span>
+          </div>
+
+          <div className="flex gap-3 pt-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="lg"
+              onClick={onBack}
+              className="h-14 w-1/3 rounded-full border border-border bg-transparent font-semibold text-foreground hover:bg-secondary"
+            >
+              {a("back")}
+            </Button>
+            <Button
+              type="submit"
+              size="lg"
+              disabled={!isValid}
+              className="h-14 flex-1 rounded-full bg-foreground text-background font-bold text-base hover:bg-foreground/90 transition-all disabled:opacity-40"
+            >
+              {a("verify")}
+            </Button>
+          </div>
+        </>
+      )}
+    </form>
+  );
+}

--- a/components/app/registration-steps/progress-indicator.tsx
+++ b/components/app/registration-steps/progress-indicator.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { cn } from "@/lib/utils";
+import { Check } from "lucide-react";
+
+const STEP_COUNT = 3;
+
+export function ProgressIndicator({ current }: { current: number }) {
+  const t = useTranslations("auth.registroSteps.progress");
+
+  return (
+    <div className="mb-10 mt-6">
+      <div className="flex items-center justify-center gap-2">
+        {Array.from({ length: STEP_COUNT }, (_, i) => {
+          const isActive = i === current;
+          const isCompleted = i < current;
+          const label = t(`step${i + 1}` as "step1" | "step2" | "step3");
+
+          return (
+            <div key={i} className="flex items-center gap-2">
+              <div className="flex flex-col items-center">
+                <div
+                  className={cn(
+                    "flex h-8 w-8 items-center justify-center rounded-full text-xs font-bold transition-all duration-300",
+                    isCompleted &&
+                      "bg-foreground text-background",
+                    isActive &&
+                      "border-2 border-foreground bg-background text-foreground",
+                    !isActive &&
+                      !isCompleted &&
+                      "border border-muted-foreground/30 bg-secondary text-muted-foreground",
+                  )}
+                >
+                  {isCompleted ? (
+                    <Check className="h-4 w-4" />
+                  ) : (
+                    i + 1
+                  )}
+                </div>
+                <span
+                  className={cn(
+                    "mt-1.5 text-[10px] font-medium transition-colors",
+                    isActive || isCompleted
+                      ? "text-foreground"
+                      : "text-muted-foreground",
+                  )}
+                >
+                  {label}
+                </span>
+              </div>
+              {i < STEP_COUNT - 1 && (
+                <div
+                  className={cn(
+                    "mx-1 h-px w-8 transition-colors",
+                    isCompleted
+                      ? "bg-foreground"
+                      : "bg-muted-foreground/20",
+                  )}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/app/registration-steps/success-confirmation.tsx
+++ b/components/app/registration-steps/success-confirmation.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { CheckCircle } from "lucide-react";
+
+interface Props {
+  onResendOtp?: () => void;
+}
+
+export function SuccessConfirmation({ onResendOtp }: Props) {
+  const t = useTranslations("auth.registroSteps.success");
+  const [resent, setResent] = useState(false);
+
+  const handleResend = () => {
+    onResendOtp?.();
+    setResent(true);
+    setTimeout(() => setResent(false), 3000);
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center text-center">
+      <div className="mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-emerald-100 dark:bg-emerald-900/30">
+        <CheckCircle className="h-10 w-10 text-emerald-600 dark:text-emerald-400" />
+      </div>
+
+      <h2 className="text-3xl font-black tracking-tight text-foreground">
+        {t("heading")}
+      </h2>
+
+      <p className="mt-4 text-base text-muted-foreground leading-relaxed max-w-xs">
+        {t("subtitle")}
+      </p>
+
+      <p className="mt-6 text-xs text-muted-foreground">
+        {resent ? (
+          <span className="text-emerald-600 font-semibold">
+            {t("resent")}
+          </span>
+        ) : (
+          <button
+            type="button"
+            onClick={handleResend}
+            className="underline underline-offset-4 hover:text-foreground"
+          >
+            {t("resend")}
+          </button>
+        )}
+      </p>
+
+      <div className="mt-8 w-full">
+        <Link href="/login">
+          <Button
+            size="lg"
+            className="w-full h-14 rounded-full bg-foreground text-background font-bold text-base hover:bg-foreground/90 transition-all"
+          >
+            {t("cta")}
+          </Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/lib/seyf/dashboard-view-model.ts
+++ b/lib/seyf/dashboard-view-model.ts
@@ -10,7 +10,6 @@ import {
 } from "@/lib/seyf/dashboard-cetes-saldo";
 import { resolveEtherfuseRampContext } from "@/lib/seyf/etherfuse-ramp-context";
 import { fetchUserMovements } from "@/lib/seyf/user-movements";
-import { getActiveCycle } from "@/lib/seyf/cycle-store";
 import {
   DASHBOARD_MOVEMENTS_PREVIEW_LIMIT,
   type DashboardViewModel,
@@ -96,7 +95,6 @@ export async function buildDashboardViewModel(options?: {
 
   const activeCycle = ledgerUserKey ? getActiveCycle(ledgerUserKey) : null;
   const ledgerPrincipal = ledgerPrincipalMxn(investRuns);
-  const activeCycle = ledgerUserKey ? getActiveCycle(ledgerUserKey) : null;
   const cyclePrincipal = activeCycle?.principalMxn ?? 0;
   let principalMxn: number;
   if (cetesSaldo.kind === "ok") principalMxn = cetesSaldo.principalMxn;

--- a/messages/es-MX.json
+++ b/messages/es-MX.json
@@ -23,7 +23,7 @@
       "passwordPlaceholder": "Contrasena",
       "submitLoading": "Entrando...",
       "submit": "Iniciar sesion",
-      "forgotPassword": "Olvide mi contrasena",
+      "forgotPassword": "¿Olvidaste tu contraseña?",
       "noAccount": "No tienes cuenta?",
       "createAccount": "Crear cuenta"
     },
@@ -44,12 +44,91 @@
       "submit": "Continuar",
       "hasAccount": "Ya tienes cuenta?",
       "loginLink": "Iniciar sesion"
+    },
+    "registroSteps": {
+      "step1": {
+        "title": "Cuenta",
+        "heading": "Tu cuenta",
+        "subtitle": "Ingresa tus datos personales para empezar.",
+        "nameLabel": "Nombre completo",
+        "namePlaceholder": "Nombre completo",
+        "emailLabel": "Correo electrónico",
+        "emailPlaceholder": "Correo electrónico",
+        "passwordLabel": "Contraseña",
+        "passwordPlaceholder": "Contraseña"
+      },
+      "step2": {
+        "title": "Negocio",
+        "heading": "Tu negocio",
+        "subtitle": "Información de tu empresa o actividad profesional.",
+        "businessNameLabel": "Nombre del negocio",
+        "businessNamePlaceholder": "Nombre del negocio",
+        "rfcLabel": "RFC",
+        "rfcPlaceholder": "RFC (13 caracteres)",
+        "curpLabel": "CURP",
+        "curpPlaceholder": "CURP (18 caracteres)"
+      },
+      "step3": {
+        "title": "Verificación",
+        "heading": "Verifica tu teléfono",
+        "subtitle": "Ingresa el código que enviamos a tu teléfono.",
+        "phoneLabel": "Teléfono (10 dígitos)",
+        "phonePlaceholder": "Teléfono (10 dígitos)",
+        "otpLabel": "Código de verificación",
+        "otpPlaceholder": "Ingresa el código de 6 dígitos",
+        "resend": "Reenviar código",
+        "resendCountdown": "Reenviar en {seconds}s",
+        "sent": "Código enviado"
+      },
+      "progress": {
+        "step1": "Cuenta",
+        "step2": "Negocio",
+        "step3": "Verificación"
+      },
+      "success": {
+        "title": "Cuenta creada",
+        "heading": "¡Listo!",
+        "subtitle": "Tu cuenta está en proceso de verificación. Te notificaremos cuando esté activa.",
+        "resend": "¿No recibiste el código? Reenviar",
+        "resent": "¡Código reenviado!",
+        "cta": "Ir al inicio"
+      },
+      "actions": {
+        "continue": "Continuar",
+        "back": "Atrás",
+        "verify": "Verificar código",
+        "verifying": "Verificando..."
+      },
+      "validation": {
+        "nameRequired": "El nombre es obligatorio",
+        "nameMin": "El nombre debe tener al menos 2 caracteres",
+        "emailRequired": "El correo es obligatorio",
+        "emailInvalid": "Correo electrónico inválido",
+        "passwordRequired": "La contraseña es obligatoria",
+        "passwordMin": "Mínimo 8 caracteres",
+        "passwordUppercase": "Una mayúscula",
+        "passwordLowercase": "Una minúscula",
+        "passwordNumber": "Un número",
+        "passwordSpecial": "Un carácter especial",
+        "businessNameRequired": "El nombre del negocio es obligatorio",
+        "rfcRequired": "El RFC es obligatorio",
+        "rfcInvalid": "RFC inválido (13 caracteres)",
+        "curpRequired": "La CURP es obligatoria",
+        "curpInvalid": "CURP inválida (18 caracteres)",
+        "phoneRequired": "El teléfono es obligatorio",
+        "phoneInvalid": "Número inválido (10 dígitos)",
+        "otpRequired": "El código es obligatorio",
+        "otpInvalid": "El código debe ser de 6 dígitos"
+      }
     }
   },
   "dashboard": {
     "connectWallet": "Conecta tu wallet",
     "connectWalletBody": "Para ver tu saldo y movimientos, inicia sesión en tu cuenta.",
     "connectAction": "Ir a conectar",
+    "emptyStateTitle": "Tu capital está listo para trabajar.",
+    "emptyStateBody": "Deposita para empezar.",
+    "emptyStateCta": "Depositar",
     "mainAccount": "Cuenta principal",
     "lastUpdate": "Última actualización",
     "showBalances": "Mostrar saldos",


### PR DESCRIPTION
## M11-T01 — Onboarding Flow: Multi-Step Registration & Empty States

Closes #41 

### Summary
Rewrote `/registro` as a 3-step merchant onboarding wizard with real-time Zod validation, direction-aware slide animations, and a success confirmation screen. Updated `/login` with forgot-password link and layout polish. Replaced the dashboard's crypto-framed "Conecta tu wallet" fallback with a merchant-framed empty-state card.

### Changes

#### `app/registro/page.tsx` + `components/app/registration-steps/` (new)
Full multi-step registration flow:
- **Step 1 – Account**: Name, email, password with live Zod validation and dynamic password requirements checklist (✓/✗ per rule: length, uppercase, lowercase, number, special char)
- **Step 2 – Business**: Business name, RFC (13 chars), CURP (18 chars) with regex validation
- **Step 3 – Phone**: Phone entry + OTP send/verify with 30s resend countdown
- **SuccessConfirmation**: "¡Listo!" screen with resend OTP link and "Ir al inicio" CTA
- **ProgressIndicator**: 3-step numbered dots with checkmarks on completed steps, labels below each dot
- Key-based remount slide animations via plain `<style>` tag (direction-aware: right on forward, left on back), cubic-bezier easing — no animation library
- Layout matches `/login`: full-background, Seyf logo header, centered `max-w-md` content area, bottom "Ya tienes cuenta?" link

#### `app/login/page.tsx`
- Added `max-w-md mx-auto` wrapper for desktop form width consistency
- Moved "Bienvenido de vuelta." to single line (removed `<br />`)
- Forgot-password link now uses translation key and points to `/recuperar`
- Nested bottom link inside `max-w-md` wrapper for alignment

#### `components/app/dashboard-client.tsx`
- Removed `!wallet` gate ("Conecta tu wallet" fallback block, lines 85–92 in original)
- Replaced no-active-cycle `EmptyState` from `illustration="cycle"` to `illustration="balance"` with copy: *"Tu capital está listo para trabajar. Deposita para empezar."* and CTA to `/depositar`
- Fixed pre-existing duplicate `Skeleton`/`useTranslations` imports

#### `messages/es-MX.json`
- Added full `auth.registroSteps` translation namespace (step labels, field labels/placeholders, action buttons, validation messages, success copy, progress labels)
- Added `auth.login.forgotPassword` key
- Added `dashboard.emptyStateTitle`, `.emptyStateBody`, `.emptyStateCta` keys

#### `lib/seyf/dashboard-view-model.ts`
- Fixed pre-existing duplicate `getActiveCycle` import and duplicate `const activeCycle` declaration

#### `app/(app)/historial/historial-page-client.tsx`
- Fixed pre-existing duplicate `Skeleton`/`useTranslations` imports

### Technical Notes
- **Validation**: Zod schemas per step with `react-hook-form` + `@hookform/resolvers/zod`, validated on change
- **CTA**: Disabled via `!isValid` until all required fields in current step pass validation
- **Animations**: CSS `@keyframes` in a plain `<style>` tag (not `styled-jsx`, which causes React 19 reconciler errors)
- **State**: Local `useState` for step tracking + `useRef` for direction detection
- **Resolved reconciler bug**: `styled-jsx`'s scoped `<style>` injection conflicts with React 19.2.4's DOM reconciliation. Replaced with global `<style>` tag + remount-on-key-change pattern.
- **Resolved `insertBefore` bug**: Lucide-react `Check`/`X` SVG icons conditionally rendered inside fast re-rendering maps trigger React 19 reconciler errors. Replaced with plain Unicode characters `✓`/`✗`.

### Demo

https://github.com/user-attachments/assets/2d1dad6f-5c85-46fb-a42b-9f1cfb2b233e

