### PR TITLE
feat(admin): internal admin KYC review queue, actions & audit trail

### DIFF
--- a/app/api/admin/kyc/[customerId]/approve/route.ts
+++ b/app/api/admin/kyc/[customerId]/approve/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { assertAdminAccess } from "@/lib/seyf/admin-auth";
+import { approveKycCase } from "@/lib/seyf/kyc-review-service";
+import { logger } from "@/lib/observability/logger";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+type RouteContext = { params: Promise<{ customerId: string }> };
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  try {
+    assertAdminAccess(request);
+
+    const { customerId } = await context.params;
+    if (!customerId) {
+      return NextResponse.json(
+        { ok: false, error: "customerId is required" },
+        { status: 400 }
+      );
+    }
+
+    let body: any;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json(
+        { ok: false, error: "Invalid JSON body" },
+        { status: 400 }
+      );
+    }
+
+    const { walletPublicKey, note } = body;
+    if (!walletPublicKey || typeof walletPublicKey !== "string") {
+      return NextResponse.json(
+        { ok: false, error: "walletPublicKey is required and must be a string" },
+        { status: 400 }
+      );
+    }
+
+    const opsToken = process.env.SEYF_ETHERFUSE_OPS_TOKEN?.trim();
+    const opsHeader = request.headers.get("x-seyf-ops-token")?.trim();
+    const tokenActor = opsHeader && opsHeader === opsToken ? "ops_token" : "admin_secret";
+    const actor = request.headers.get("x-actor-name") || request.headers.get("x-admin-email") || tokenActor;
+
+    const result = await approveKycCase({
+      customerId,
+      walletPublicKey,
+      actor,
+      note,
+    });
+
+    if (!result.ok) {
+      return NextResponse.json(
+        { ok: false, error: result.reason },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json({
+      ok: true,
+      customerId,
+      walletPublicKey,
+      fromStatus: result.fromStatus,
+      toStatus: "approved",
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to approve KYC case";
+    logger.error({ route: "admin/kyc/approve", error: message }, message);
+    return NextResponse.json(
+      { ok: false, error: message },
+      { status: error instanceof Error && "statusCode" in error ? (error as any).statusCode : 500 },
+    );
+  }
+}

--- a/app/api/admin/kyc/[customerId]/reject/route.ts
+++ b/app/api/admin/kyc/[customerId]/reject/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { assertAdminAccess } from "@/lib/seyf/admin-auth";
+import { rejectKycCase } from "@/lib/seyf/kyc-review-service";
+import { logger } from "@/lib/observability/logger";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+type RouteContext = { params: Promise<{ customerId: string }> };
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  try {
+    assertAdminAccess(request);
+
+    const { customerId } = await context.params;
+    if (!customerId) {
+      return NextResponse.json(
+        { ok: false, error: "customerId is required" },
+        { status: 400 }
+      );
+    }
+
+    let body: any;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json(
+        { ok: false, error: "Invalid JSON body" },
+        { status: 400 }
+      );
+    }
+
+    const { walletPublicKey, rejectionReason, note } = body;
+    if (!walletPublicKey || typeof walletPublicKey !== "string") {
+      return NextResponse.json(
+        { ok: false, error: "walletPublicKey is required and must be a string" },
+        { status: 400 }
+      );
+    }
+    if (!rejectionReason || typeof rejectionReason !== "string") {
+      return NextResponse.json(
+        { ok: false, error: "rejectionReason is required and must be a string" },
+        { status: 400 }
+      );
+    }
+
+    const opsToken = process.env.SEYF_ETHERFUSE_OPS_TOKEN?.trim();
+    const opsHeader = request.headers.get("x-seyf-ops-token")?.trim();
+    const tokenActor = opsHeader && opsHeader === opsToken ? "ops_token" : "admin_secret";
+    const actor = request.headers.get("x-actor-name") || request.headers.get("x-admin-email") || tokenActor;
+
+    const result = await rejectKycCase({
+      customerId,
+      walletPublicKey,
+      actor,
+      rejectionReason,
+      note,
+    });
+
+    if (!result.ok) {
+      return NextResponse.json(
+        { ok: false, error: result.reason },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json({
+      ok: true,
+      customerId,
+      walletPublicKey,
+      fromStatus: result.fromStatus,
+      toStatus: "rejected",
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to reject KYC case";
+    logger.error({ route: "admin/kyc/reject", error: message }, message);
+    return NextResponse.json(
+      { ok: false, error: message },
+      { status: error instanceof Error && "statusCode" in error ? (error as any).statusCode : 500 },
+    );
+  }
+}

--- a/app/api/admin/kyc/audit-log/route.ts
+++ b/app/api/admin/kyc/audit-log/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { assertAdminAccess } from "@/lib/seyf/admin-auth";
+import { listKycAuditLog } from "@/lib/seyf/kyc-review-service";
+import { logger } from "@/lib/observability/logger";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function GET(req: Request) {
+  try {
+    assertAdminAccess(req);
+
+    const url = new URL(req.url);
+    const customerId = url.searchParams.get("customer_id") || undefined;
+    const limitParam = url.searchParams.get("limit");
+
+    const limit = limitParam ? Math.max(1, Number.parseInt(limitParam, 10)) : 50;
+
+    const logs = await listKycAuditLog({ customerId, limit });
+
+    return NextResponse.json({
+      ok: true,
+      count: logs.length,
+      logs,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to list KYC audit logs";
+    logger.error({ route: "admin/kyc/audit-log", error: message }, message);
+    return NextResponse.json(
+      { ok: false, error: message },
+      { status: error instanceof Error && "statusCode" in error ? (error as any).statusCode : 500 },
+    );
+  }
+}

--- a/app/api/admin/kyc/queue/route.ts
+++ b/app/api/admin/kyc/queue/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { assertAdminAccess } from "@/lib/seyf/admin-auth";
+import { listKycCases } from "@/lib/seyf/kyc-review-service";
+import type { EtherfuseKycStatus } from "@/lib/etherfuse/kyc";
+import { logger } from "@/lib/observability/logger";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function GET(req: Request) {
+  try {
+    assertAdminAccess(req);
+
+    const url = new URL(req.url);
+    const statusParam = url.searchParams.get("status");
+    const limitParam = url.searchParams.get("limit");
+
+    const limit = limitParam ? Math.max(1, Number.parseInt(limitParam, 10)) : 50;
+    const status = statusParam ? (statusParam as EtherfuseKycStatus) : "proposed";
+
+    const cases = await listKycCases({ status, limit });
+
+    return NextResponse.json({
+      ok: true,
+      count: cases.length,
+      cases,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to list KYC queue";
+    logger.error({ route: "admin/kyc/queue", error: message }, message);
+    return NextResponse.json(
+      { ok: false, error: message },
+      { status: error instanceof Error && "statusCode" in error ? (error as any).statusCode : 500 },
+    );
+  }
+}

--- a/docs/admin-kyc-review.md
+++ b/docs/admin-kyc-review.md
@@ -1,0 +1,180 @@
+# Internal Admin KYC Review API
+
+This document provides a reference for the internal admin APIs used for reviewing, approving, and rejecting KYC submissions in Seyf.
+
+## Admin Access Control
+
+Access to all `/api/admin/*` endpoints is controlled via the `assertAdminAccess()` middleware. Access is granted if either of the following environment variables is set and the corresponding header is provided in the request:
+
+1. **`SEYF_ETHERFUSE_OPS_TOKEN`**: Checked against the `x-seyf-ops-token` request header.
+2. **`ADMIN_SECRET`**: Checked against the standard `Authorization: Bearer <ADMIN_SECRET>` header.
+
+If neither environment variable is configured in production, the API endpoints will return a `503 Service Unavailable` error.
+
+---
+
+## API Endpoints Reference
+
+### 1. GET /api/admin/kyc/queue
+
+Fetch the list of KYC cases stored in Redis, filtered by status.
+
+- **Query Parameters**:
+  - `status` (optional): The KYC status to filter by. Defaults to `proposed`. Allowed values: `not_started`, `proposed`, `approved`, `approved_chain_deploying`, `rejected`.
+  - `limit` (optional): Maximum number of cases to return. Defaults to `50`.
+
+- **Example Request**:
+  ```bash
+  curl -X GET "https://api.seyf.app/api/admin/kyc/queue?status=proposed&limit=10" \
+    -H "x-seyf-ops-token: YOUR_OPS_TOKEN"
+  ```
+
+- **Example Response**:
+  ```json
+  {
+    "ok": true,
+    "count": 1,
+    "cases": [
+      {
+        "customerId": "cust_123",
+        "walletPublicKey: "G...",
+        "status": "proposed",
+        "approvedAt": null,
+        "currentRejectionReason": null,
+        "updatedAt": "2026-06-24T12:00:00.000Z"
+      }
+    ]
+  }
+  ```
+
+---
+
+### 2. PATCH /api/admin/kyc/[customerId]/approve
+
+Approve a customer's KYC submission, transition their state in Redis to `approved`, and record the action in the audit log.
+
+- **Request Body**:
+  - `walletPublicKey` (string, required): The wallet public key associated with the KYC record.
+  - `note` (string, optional): A descriptive note about the approval.
+
+- **Example Request**:
+  ```bash
+  curl -X PATCH "https://api.seyf.app/api/admin/kyc/cust_123/approve" \
+    -H "x-seyf-ops-token: YOUR_OPS_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "walletPublicKey": "GBX...",
+      "note": "Document validation verified manually."
+    }'
+  ```
+
+- **Example Response**:
+  ```json
+  {
+    "ok": true,
+    "customerId": "cust_123",
+    "walletPublicKey": "GBX...",
+    "fromStatus": "proposed",
+    "toStatus": "approved"
+  }
+  ```
+
+---
+
+### 3. PATCH /api/admin/kyc/[customerId]/reject
+
+Reject a customer's KYC submission, transition their state in Redis to `rejected`, and record the action and reason in the audit log.
+
+- **Request Body**:
+  - `walletPublicKey` (string, required): The wallet public key associated with the KYC record.
+  - `rejectionReason` (string, required): The reason for rejection (e.g., "id_expired", "poor_quality_selfie").
+  - `note` (string, optional): A descriptive note about the rejection.
+
+- **Example Request**:
+  ```bash
+  curl -X PATCH "https://api.seyf.app/api/admin/kyc/cust_123/reject" \
+    -H "x-seyf-ops-token: YOUR_OPS_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "walletPublicKey": "GBX...",
+      "rejectionReason": "poor_quality_selfie",
+      "note": "Selfie was blurry. Please resubmit."
+    }'
+  ```
+
+- **Example Response**:
+  ```json
+  {
+    "ok": true,
+    "customerId": "cust_123",
+    "walletPublicKey": "GBX...",
+    "fromStatus": "proposed",
+    "toStatus": "rejected"
+  }
+  ```
+
+---
+
+### 4. GET /api/admin/kyc/audit-log
+
+Retrieve the audit trail of KYC review actions from the Postgres database.
+
+- **Query Parameters**:
+  - `customer_id` (optional): Filter audit records by customer ID.
+  - `limit` (optional): Maximum number of entries to return. Defaults to `50`, maximum `200`.
+
+- **Example Request**:
+  ```bash
+  curl -X GET "https://api.seyf.app/api/admin/kyc/audit-log?limit=25" \
+    -H "x-seyf-ops-token: YOUR_OPS_TOKEN"
+  ```
+
+- **Example Response**:
+  ```json
+  {
+    "ok": true,
+    "count": 2,
+    "logs": [
+      {
+        "id": "7857fa23-...",
+        "actor": "ops_token",
+        "action": "reject",
+        "target_customer_id": "cust_123",
+        "target_wallet_public_key": "GBX...",
+        "from_status": "proposed",
+        "to_status": "rejected",
+        "note": "Selfie was blurry. Please resubmit.",
+        "created_at": "2026-06-24T12:05:00.000Z"
+      },
+      {
+        "id": "91a84f3e-...",
+        "actor": "admin_secret",
+        "action": "approve",
+        "target_customer_id": "cust_456",
+        "target_wallet_public_key": "GCV...",
+        "from_status": "proposed",
+        "to_status": "approved",
+        "note": "Approved on second submission.",
+        "created_at": "2026-06-24T12:10:00.000Z"
+      }
+    ]
+  }
+  ```
+
+---
+
+## Audit Log Database Schema
+
+Audit entries are persisted in the `kyc_review_audit_log` table in PostgreSQL. The table is append-only for security and durability.
+
+| Column | Type | Constraints | Description |
+|---|---|---|---|
+| `id` | `uuid` | `primary key`, default `gen_random_uuid()` | Unique identifier for the audit entry |
+| `actor` | `text` | `not null` | Name/ID of the admin performing the action (extracted from auth headers or fallback) |
+| `action` | `text` | `not null`, `check (action in ('approve', 'reject'))` | The type of action performed |
+| `target_customer_id` | `text` | `not null` | The Etherfuse customer ID of the target KYC case |
+| `target_wallet_public_key` | `text` | `not null` | The wallet public key of the target KYC case |
+| `from_status` | `text` | `nullable` | The KYC status prior to this action |
+| `to_status` | `text` | `not null` | The KYC status transitioned to by this action |
+| `note` | `text` | `nullable` | Additional comments/reasons provided by the admin |
+| `created_at` | `timestamptz`| `not null`, default `now()` | Timestamp when the action was recorded |

--- a/lib/seyf/__tests__/kyc-review-service.test.ts
+++ b/lib/seyf/__tests__/kyc-review-service.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  approveKycCase,
+  rejectKycCase,
+  listKycCases,
+  listKycAuditLog,
+} from "../kyc-review-service";
+import { query } from "@/lib/seyf/db/client";
+import {
+  getStoredKycSnapshot,
+  listStoredKycRows,
+  upsertStoredKycSnapshot,
+} from "@/lib/seyf/kyc-state-store";
+
+vi.mock("@/lib/seyf/db/client", () => ({
+  query: vi.fn(),
+}));
+
+vi.mock("@/lib/seyf/kyc-state-store", () => ({
+  getStoredKycSnapshot: vi.fn(),
+  listStoredKycRows: vi.fn(),
+  upsertStoredKycSnapshot: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("kyc-review-service", () => {
+  describe("listKycCases", () => {
+    it("lists and filters cases correctly, sorted newest first", async () => {
+      const mockRows = [
+        {
+          customerId: "c1",
+          walletPublicKey: "w1",
+          status: "proposed" as const,
+          approvedAt: null,
+          currentRejectionReason: null,
+          updatedAt: "2026-06-24T10:00:00.000Z",
+        },
+        {
+          customerId: "c2",
+          walletPublicKey: "w2",
+          status: "approved" as const,
+          approvedAt: "2026-06-24T11:00:00.000Z",
+          currentRejectionReason: null,
+          updatedAt: "2026-06-24T11:00:00.000Z",
+        },
+      ];
+
+      vi.mocked(listStoredKycRows).mockResolvedValue(mockRows);
+
+      const allResult = await listKycCases();
+      expect(allResult).toHaveLength(2);
+      expect(allResult[0].customerId).toBe("c2"); // sorted newest first
+
+      const filteredResult = await listKycCases({ status: "proposed" });
+      expect(filteredResult).toHaveLength(1);
+      expect(filteredResult[0].customerId).toBe("c1");
+    });
+  });
+
+  describe("approveKycCase", () => {
+    it("successfully approves a pending KYC case", async () => {
+      vi.mocked(getStoredKycSnapshot).mockResolvedValue({
+        customerId: "c1",
+        walletPublicKey: "w1",
+        status: "proposed",
+        approvedAt: null,
+        currentRejectionReason: null,
+        verifiedProfile: null,
+        documentsCount: 0,
+        selfiesCount: 0,
+      });
+
+      vi.mocked(upsertStoredKycSnapshot).mockResolvedValue({ updated: true });
+      vi.mocked(query).mockResolvedValue({ rows: [] } as any);
+
+      const result = await approveKycCase({
+        customerId: "c1",
+        walletPublicKey: "w1",
+        actor: "admin1",
+        note: "looks good",
+      });
+
+      expect(result).toEqual({ ok: true, fromStatus: "proposed" });
+      expect(upsertStoredKycSnapshot).toHaveBeenCalledWith(
+        expect.objectContaining({
+          customerId: "c1",
+          walletPublicKey: "w1",
+          status: "approved",
+        })
+      );
+      expect(query).toHaveBeenCalledWith(
+        expect.stringContaining("insert into kyc_review_audit_log"),
+        expect.arrayContaining(["admin1", "approve", "c1", "w1", "proposed", "approved", "looks good"])
+      );
+    });
+
+    it("returns error if already approved", async () => {
+      vi.mocked(getStoredKycSnapshot).mockResolvedValue({
+        customerId: "c1",
+        walletPublicKey: "w1",
+        status: "approved",
+        approvedAt: "2026-06-24T10:00:00.000Z",
+        currentRejectionReason: null,
+        verifiedProfile: null,
+        documentsCount: 0,
+        selfiesCount: 0,
+      });
+
+      const result = await approveKycCase({
+        customerId: "c1",
+        walletPublicKey: "w1",
+        actor: "admin1",
+      });
+
+      expect(result.ok).toBe(false);
+      expect(upsertStoredKycSnapshot).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("rejectKycCase", () => {
+    it("successfully rejects a KYC case", async () => {
+      vi.mocked(getStoredKycSnapshot).mockResolvedValue({
+        customerId: "c1",
+        walletPublicKey: "w1",
+        status: "proposed",
+        approvedAt: null,
+        currentRejectionReason: null,
+        verifiedProfile: null,
+        documentsCount: 0,
+        selfiesCount: 0,
+      });
+
+      vi.mocked(upsertStoredKycSnapshot).mockResolvedValue({ updated: true });
+      vi.mocked(query).mockResolvedValue({ rows: [] } as any);
+
+      const result = await rejectKycCase({
+        customerId: "c1",
+        walletPublicKey: "w1",
+        actor: "admin1",
+        rejectionReason: "bad selfie",
+        note: "please re-take selfie",
+      });
+
+      expect(result).toEqual({ ok: true, fromStatus: "proposed" });
+      expect(upsertStoredKycSnapshot).toHaveBeenCalledWith(
+        expect.objectContaining({
+          customerId: "c1",
+          walletPublicKey: "w1",
+          status: "rejected",
+          currentRejectionReason: "bad selfie",
+        })
+      );
+      expect(query).toHaveBeenCalledWith(
+        expect.stringContaining("insert into kyc_review_audit_log"),
+        expect.arrayContaining(["admin1", "reject", "c1", "w1", "proposed", "rejected", "please re-take selfie"])
+      );
+    });
+  });
+
+  describe("listKycAuditLog", () => {
+    it("queries database and formats results", async () => {
+      const mockDbRows = [
+        {
+          id: "uuid-1",
+          actor: "admin1",
+          action: "approve",
+          target_customer_id: "c1",
+          target_wallet_public_key: "w1",
+          from_status: "proposed",
+          to_status: "approved",
+          note: "approved manually",
+          created_at: new Date("2026-06-24T12:00:00.000Z"),
+        },
+      ];
+
+      vi.mocked(query).mockResolvedValue({ rows: mockDbRows } as any);
+
+      const result = await listKycAuditLog({ customerId: "c1", limit: 10 });
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        id: "uuid-1",
+        actor: "admin1",
+        action: "approve",
+        target_customer_id: "c1",
+        target_wallet_public_key: "w1",
+        from_status: "proposed",
+        to_status: "approved",
+        note: "approved manually",
+        created_at: "2026-06-24T12:00:00.000Z",
+      });
+      expect(query).toHaveBeenCalledWith(
+        expect.stringContaining("where target_customer_id = $1"),
+        ["c1", 10]
+      );
+    });
+  });
+});

--- a/lib/seyf/kyc-review-service.ts
+++ b/lib/seyf/kyc-review-service.ts
@@ -1,0 +1,224 @@
+import { query } from "@/lib/seyf/db/client";
+import {
+  getStoredKycSnapshot,
+  listStoredKycRows,
+  upsertStoredKycSnapshot,
+} from "@/lib/seyf/kyc-state-store";
+import type { EtherfuseKycStatus } from "@/lib/etherfuse/kyc";
+import { logger } from "@/lib/observability/logger";
+
+export type KycReviewAction = "approve" | "reject";
+
+export type KycReviewAuditEntry = {
+  id: string;
+  actor: string;
+  action: KycReviewAction;
+  target_customer_id: string;
+  target_wallet_public_key: string;
+  from_status: string | null;
+  to_status: string;
+  note: string | null;
+  created_at: string;
+};
+
+export type KycCaseListItem = {
+  customerId: string;
+  walletPublicKey: string;
+  status: EtherfuseKycStatus;
+  approvedAt: string | null;
+  currentRejectionReason: string | null;
+  updatedAt: string;
+};
+
+export async function listKycCases(options?: {
+  status?: EtherfuseKycStatus;
+  limit?: number;
+}): Promise<KycCaseListItem[]> {
+  const limit = options?.limit ?? 100;
+  const rows = await listStoredKycRows(limit);
+  let filtered = rows;
+  if (options?.status) {
+    filtered = rows.filter((r) => r.status === options.status);
+  }
+  filtered.sort((a, b) => {
+    const ta = new Date(a.updatedAt).getTime();
+    const tb = new Date(b.updatedAt).getTime();
+    return tb - ta;
+  });
+  return filtered;
+}
+
+async function insertAuditLog(params: {
+  actor: string;
+  action: KycReviewAction;
+  targetCustomerId: string;
+  targetWalletPublicKey: string;
+  fromStatus: string | null;
+  toStatus: string;
+  note: string | null;
+}): Promise<void> {
+  await query(
+    `insert into kyc_review_audit_log
+       (actor, action, target_customer_id, target_wallet_public_key, from_status, to_status, note)
+     values ($1, $2, $3, $4, $5, $6, $7)`,
+    [
+      params.actor,
+      params.action,
+      params.targetCustomerId,
+      params.targetWalletPublicKey,
+      params.fromStatus,
+      params.toStatus,
+      params.note,
+    ],
+  );
+}
+
+export async function approveKycCase(params: {
+  customerId: string;
+  walletPublicKey: string;
+  actor: string;
+  note?: string | null;
+}): Promise<{ ok: true; fromStatus: string | null } | { ok: false; reason: string }> {
+  const snapshot = await getStoredKycSnapshot(params.customerId, params.walletPublicKey);
+  const fromStatus = snapshot?.status ?? null;
+
+  if (fromStatus === "approved" || fromStatus === "approved_chain_deploying") {
+    return { ok: false, reason: "KYC already approved." };
+  }
+
+  const { updated } = await upsertStoredKycSnapshot({
+    customerId: params.customerId,
+    walletPublicKey: params.walletPublicKey,
+    status: "approved",
+    approvedAt: new Date().toISOString(),
+    currentRejectionReason: null,
+  });
+
+  if (!updated && snapshot) {
+    return { ok: false, reason: "No state change applied." };
+  }
+
+  try {
+    await insertAuditLog({
+      actor: params.actor,
+      action: "approve",
+      targetCustomerId: params.customerId,
+      targetWalletPublicKey: params.walletPublicKey,
+      fromStatus,
+      toStatus: "approved",
+      note: params.note ?? null,
+    });
+  } catch (e) {
+    logger.error(
+      { customerId: params.customerId, error: e instanceof Error ? e.message : String(e) },
+      "Failed to write KYC audit log for approve",
+    );
+  }
+
+  logger.info(
+    { customerId: params.customerId, actor: params.actor, fromStatus, toStatus: "approved" },
+    "KYC case approved by admin",
+  );
+
+  return { ok: true, fromStatus };
+}
+
+export async function rejectKycCase(params: {
+  customerId: string;
+  walletPublicKey: string;
+  actor: string;
+  rejectionReason: string;
+  note?: string | null;
+}): Promise<{ ok: true; fromStatus: string | null } | { ok: false; reason: string }> {
+  const snapshot = await getStoredKycSnapshot(params.customerId, params.walletPublicKey);
+  const fromStatus = snapshot?.status ?? null;
+
+  if (fromStatus === "rejected") {
+    return { ok: false, reason: "KYC already rejected." };
+  }
+
+  const { updated } = await upsertStoredKycSnapshot({
+    customerId: params.customerId,
+    walletPublicKey: params.walletPublicKey,
+    status: "rejected",
+    approvedAt: null,
+    currentRejectionReason: params.rejectionReason,
+  });
+
+  if (!updated && snapshot) {
+    return { ok: false, reason: "No state change applied." };
+  }
+
+  try {
+    await insertAuditLog({
+      actor: params.actor,
+      action: "reject",
+      targetCustomerId: params.customerId,
+      targetWalletPublicKey: params.walletPublicKey,
+      fromStatus,
+      toStatus: "rejected",
+      note: params.note ?? null,
+    });
+  } catch (e) {
+    logger.error(
+      { customerId: params.customerId, error: e instanceof Error ? e.message : String(e) },
+      "Failed to write KYC audit log for reject",
+    );
+  }
+
+  logger.info(
+    { customerId: params.customerId, actor: params.actor, fromStatus, toStatus: "rejected" },
+    "KYC case rejected by admin",
+  );
+
+  return { ok: true, fromStatus };
+}
+
+export async function listKycAuditLog(options?: {
+  customerId?: string;
+  limit?: number;
+}): Promise<KycReviewAuditEntry[]> {
+  const limit = Math.min(options?.limit ?? 50, 200);
+  const params: unknown[] = [];
+  const clauses: string[] = [];
+
+  if (options?.customerId) {
+    params.push(options.customerId);
+    clauses.push(`target_customer_id = $${params.length}`);
+  }
+
+  params.push(limit);
+  const whereSql = clauses.length > 0 ? `where ${clauses.join(" and ")}` : "";
+
+  const result = await query<{
+    id: string;
+    actor: string;
+    action: string;
+    target_customer_id: string;
+    target_wallet_public_key: string;
+    from_status: string | null;
+    to_status: string;
+    note: string | null;
+    created_at: Date;
+  }>(
+    `select id, actor, action, target_customer_id, target_wallet_public_key,
+            from_status, to_status, note, created_at
+     from kyc_review_audit_log
+     ${whereSql}
+     order by created_at desc
+     limit $${params.length}`,
+    params,
+  );
+
+  return result.rows.map((row) => ({
+    id: row.id,
+    actor: row.actor,
+    action: row.action as KycReviewAction,
+    target_customer_id: row.target_customer_id,
+    target_wallet_public_key: row.target_wallet_public_key,
+    from_status: row.from_status,
+    to_status: row.to_status,
+    note: row.note,
+    created_at: row.created_at.toISOString(),
+  }));
+}

--- a/scripts/migrations/012_kyc_review_audit_log.sql
+++ b/scripts/migrations/012_kyc_review_audit_log.sql
@@ -1,0 +1,17 @@
+create table if not exists kyc_review_audit_log (
+  id uuid primary key default gen_random_uuid(),
+  actor text not null,
+  action text not null check (action in ('approve', 'reject')),
+  target_customer_id text not null,
+  target_wallet_public_key text not null,
+  from_status text,
+  to_status text not null,
+  note text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists kyc_review_audit_log_customer_idx
+  on kyc_review_audit_log (target_customer_id, created_at desc);
+
+create index if not exists kyc_review_audit_log_created_idx
+  on kyc_review_audit_log (created_at desc);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     globals: false,
     include: [
       "lib/etherfuse/__tests__/**/*.test.ts",
+      "lib/seyf/__tests__/**/*.test.ts",
       "lib/seyf/transactions/__tests__/**/*.test.ts",
     ],
     exclude: ["node_modules/**"],


### PR DESCRIPTION
## Closes #49

## Summary
Implements the internal admin API surface for reviewing, approving, and rejecting KYC submissions, with all actions persisted to an append-only Postgres audit log while preserving existing Redis KYC state machines and status flows.

## Changes

**Database**
- Added `012_kyc_review_audit_log.sql` migration for append-only `kyc_review_audit_log` table with indices on `customer_id` and `created_at`

**Service Layer**
- Added `kyc-review-service.ts` with business logic for listing, approving, rejecting, and audit-logging KYC reviews

**API Endpoints** (following existing `assertAdminAccess` auth pattern)
- `GET /api/admin/kyc/queue`
- `PATCH /api/admin/kyc/:customerId/approve`
- `PATCH /api/admin/kyc/:customerId/reject`
- `GET /api/admin/kyc/audit-log`

**Tests**
- Added `kyc-review-service.test.ts` with service-level unit coverage

**Documentation**
- Added `docs/admin-kyc-review.md` covering authorization, endpoints with curl examples, and schema specifications

## Testing
- ✅ `npx tsc --noEmit` — 0 compiler errors
- ✅ `npx vitest run lib/seyf/__tests__/kyc-review-service.test.ts` — 5/5 tests pass