### PR TITLE
feat: Virtual CLABE Generation & Webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,11 @@ NEXT_PUBLIC_POLLAR_API_KEY=
 # Red Stellar para el SDK y Horizon (fallback: NEXT_PUBLIC_ACCESLY_NETWORK, NEXT_PUBLIC_STELLAR_NETWORK).
 NEXT_PUBLIC_POLLAR_STELLAR_NETWORK=testnet
 
+# --- SPEI Inbound Webhook (M03-T01) ---
+# Secreto HMAC-SHA256 para verificar webhooks de depósitos SPEI entrantes (POST /api/webhooks/spei/inbound).
+# Generar con: openssl rand -hex 32
+# SPEI_INBOUND_WEBHOOK_SECRET=
+
 # --- SPEI Outbound Webhook (M06-T02) ---
 # Secreto HMAC-SHA256 para verificar webhooks de estado de retiros SPEI entrantes (POST /api/webhooks/spei/outbound).
 # Generar con: openssl rand -hex 32

--- a/app/(app)/depositar/depositar-client.tsx
+++ b/app/(app)/depositar/depositar-client.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { useEffect, useRef, useState, useTransition } from "react";
+import {
+  Landmark,
+  Copy,
+  Check,
+  RefreshCw,
+  AlertCircle,
+  Sparkles,
+  CheckCircle2,
+  X,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type ClabeData = {
+  clabe: string;
+  bankName: string;
+  beneficiaryName: string;
+  reference: string;
+  depositLimitMxn: number;
+};
+
+type Props = {
+  initialClabe: ClabeData | null;
+  wallet?: string | null;
+};
+
+function CopyField({ label, value }: { label: string; value: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    await navigator.clipboard.writeText(value).catch(() => null);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2200);
+  }
+
+  return (
+    <div className="flex flex-col gap-0.5 rounded-xl border border-border/50 bg-secondary/30 px-3 py-2.5">
+      <span className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/70">
+        {label}
+      </span>
+      <button
+        type="button"
+        onClick={() => void copy()}
+        className="flex items-center justify-between gap-2 text-left"
+        aria-label={`Copiar ${label}`}
+      >
+        <span
+          className={cn(
+            "text-[13px] font-semibold text-foreground",
+            label === "CLABE" && "font-mono tracking-widest",
+          )}
+        >
+          {value}
+        </span>
+        {copied ? (
+          <Check className="size-3.5 shrink-0 text-emerald-400" />
+        ) : (
+          <Copy className="size-3.5 shrink-0 text-muted-foreground/60 transition hover:text-foreground" />
+        )}
+      </button>
+    </div>
+  );
+}
+
+function DepositBanner({ onClose }: { onClose: () => void }) {
+  useEffect(() => {
+    const t = setTimeout(onClose, 8000);
+    return () => clearTimeout(t);
+  }, [onClose]);
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex items-start gap-3 rounded-2xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 shadow-sm"
+    >
+      <CheckCircle2 className="mt-0.5 size-5 shrink-0 text-emerald-400" />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-bold text-emerald-300">Depósito recibido</p>
+        <p className="text-[12px] text-emerald-300/70 mt-0.5">
+          Tu transferencia SPEI fue registrada y está siendo procesada.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onClose}
+        className="shrink-0 text-emerald-400/60 hover:text-emerald-400 transition"
+        aria-label="Cerrar notificación"
+      >
+        <X className="size-4" />
+      </button>
+    </div>
+  );
+}
+
+export default function DepositarClient({ initialClabe, wallet }: Props) {
+  const [clabe, setClabe] = useState<ClabeData | null>(initialClabe);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const [showBanner, setShowBanner] = useState(false);
+
+  const lastDepositRef = useRef<string | null>(null);
+
+  async function provision() {
+    setError(null);
+    startTransition(async () => {
+      try {
+        const res = await fetch("/api/deposit/clabe", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ wallet }),
+        });
+        const data = await res.json().catch(() => ({})) as Partial<ClabeData> & { error?: { message_es?: string } };
+        if (!res.ok) {
+          setError(data.error?.message_es ?? "Error activando CLABE");
+          return;
+        }
+        if (data.clabe) setClabe(data as ClabeData);
+      } catch {
+        setError("Error de conexión. Intenta de nuevo.");
+      }
+    });
+  }
+
+  useEffect(() => {
+    if (!clabe) return;
+    const interval = setInterval(async () => {
+      try {
+        const res = await fetch("/api/deposit/status");
+        if (!res.ok) return;
+        const { movement } = await res.json() as { movement?: { id?: string; estado?: string } | null };
+        if (!movement?.id) return;
+        if (movement.estado === "pendiente" || movement.estado === "completado") {
+          if (lastDepositRef.current !== movement.id) {
+            lastDepositRef.current = movement.id;
+            setShowBanner(true);
+          }
+        }
+      } catch {
+        // no-op — silent poll failure
+      }
+    }, 4000);
+    return () => clearInterval(interval);
+  }, [clabe]);
+
+  return (
+    <div className="mx-auto w-full max-w-lg space-y-4 px-4 pt-4 pb-6 sm:px-6">
+      {showBanner && <DepositBanner onClose={() => setShowBanner(false)} />}
+
+      <section
+        className="relative overflow-hidden rounded-[1.75rem] border border-border"
+        aria-label="Tu CLABE de depósito"
+      >
+        <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-violet-950/80 via-card to-blue-950/60" />
+        <div className="pointer-events-none absolute -right-14 -top-20 h-52 w-52 rounded-full bg-violet-500/20 blur-3xl" />
+        <div className="pointer-events-none absolute -bottom-16 -left-10 h-44 w-44 rounded-full bg-blue-500/15 blur-3xl" />
+
+        <div className="relative px-5 pb-6 pt-5">
+          <div className="flex items-center gap-2">
+            <div className="flex size-8 items-center justify-center rounded-full bg-white/10 ring-1 ring-white/15">
+              <Landmark className="size-4 text-foreground/80" strokeWidth={1.75} />
+            </div>
+            <span className="text-[13px] font-semibold text-muted-foreground">
+              Cuenta interbancaria SPEI
+            </span>
+          </div>
+
+          <div className="mt-5">
+            {clabe ? (
+              <div className="space-y-2.5">
+                <CopyField label="CLABE" value={clabe.clabe} />
+                <CopyField label="Banco" value={clabe.bankName} />
+                <CopyField label="Beneficiario" value={clabe.beneficiaryName} />
+                <CopyField label="Referencia" value={clabe.reference} />
+
+                <div className="rounded-xl border border-border/40 bg-secondary/20 px-3.5 py-2.5 mt-1">
+                  <p className="text-[11px] text-muted-foreground leading-relaxed">
+                    Mínimo <span className="font-semibold text-foreground">$500 MXN</span> por depósito
+                    {" · "}Límite{" "}
+                    <span className="font-semibold text-foreground">
+                      ${clabe.depositLimitMxn.toLocaleString("es-MX")} MXN
+                    </span>
+                    . Los depósitos fuera de rango se reembolsan automáticamente.
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <div className="flex flex-col items-center gap-5 py-4 text-center">
+                <div className="flex size-14 items-center justify-center rounded-full bg-secondary/80 ring-1 ring-border">
+                  <Landmark className="size-6 text-muted-foreground" strokeWidth={1.75} />
+                </div>
+                <div className="space-y-1">
+                  <p className="text-sm font-semibold text-foreground">Sin CLABE activa</p>
+                  <p className="text-[13px] leading-snug text-muted-foreground">
+                    Activa tu cuenta para recibir depósitos SPEI desde cualquier banco mexicano.
+                  </p>
+                </div>
+                {error && (
+                  <div className="flex w-full items-start gap-2 rounded-xl border border-destructive/40 bg-destructive/10 px-3 py-2.5 text-left text-xs text-destructive">
+                    <AlertCircle className="mt-0.5 size-3.5 shrink-0" />
+                    <span>{error}</span>
+                  </div>
+                )}
+                <Button
+                  onClick={() => void provision()}
+                  disabled={isPending}
+                  className="h-11 w-full max-w-xs rounded-full bg-foreground text-sm font-bold text-background hover:bg-foreground/90"
+                  id="btn-activar-clabe"
+                >
+                  {isPending ? (
+                    <>
+                      <RefreshCw className="size-4 animate-spin" />
+                      Activando…
+                    </>
+                  ) : (
+                    <>
+                      <Sparkles className="size-4" />
+                      Activar CLABE
+                    </>
+                  )}
+                </Button>
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/(app)/depositar/page.tsx
+++ b/app/(app)/depositar/page.tsx
@@ -1,8 +1,33 @@
-import { redirect } from 'next/navigation'
+import { cookies } from "next/headers";
+import { getUserClabe } from "@/lib/seyf/spei-deposit-service";
+import DepositarClient from "./depositar-client";
+import { isDatabaseConfigured } from "@/lib/seyf/db/client";
 
-/**
- * Depositar → /anadir (Etherfuse ramp + CLABE de depósito).
- */
-export default function DepositarPage() {
-  redirect('/anadir')
+export const dynamic = "force-dynamic";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export default async function DepositarPage() {
+  const jar = await cookies();
+  const userId = jar.get("seyf_poc_user_id")?.value?.trim() ?? null;
+
+  let initialClabe = null;
+  if (userId && UUID_RE.test(userId) && isDatabaseConfigured()) {
+    try {
+      const record = await getUserClabe(userId);
+      if (record) {
+        initialClabe = {
+          clabe: record.clabe,
+          bankName: record.bank_name,
+          beneficiaryName: record.beneficiary_name,
+          reference: userId.slice(0, 8).toUpperCase(),
+          depositLimitMxn: record.deposit_limit_mxn,
+        };
+      }
+    } catch {
+      // DB not ready — fall through to client-side provision
+    }
+  }
+
+  return <DepositarClient initialClabe={initialClabe} />;
 }

--- a/app/api/deposit/clabe/route.ts
+++ b/app/api/deposit/clabe/route.ts
@@ -1,0 +1,130 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { resolvePocUserIdFromRequest } from "@/lib/seyf/poc-user-cookie";
+import {
+  getUserClabe,
+  upsertUserClabe,
+} from "@/lib/seyf/spei-deposit-service";
+import { resolveEtherfuseRampContext } from "@/lib/seyf/etherfuse-ramp-context";
+import { etherfuseFetch, etherfuseReadBody } from "@/lib/etherfuse/client";
+import { toErrorResponse } from "@/lib/seyf/api-error";
+import { logger } from "@/lib/observability/logger";
+import { withLogging } from "@/lib/observability/with-logging";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type BankAccountItem = {
+  bankAccountId?: string;
+  id?: string;
+  etherfuseDepositClabe?: string | null;
+  deletedAt?: string | null;
+  status?: string;
+  label?: string | null;
+};
+
+async function fetchEtherfuseDepositClabe(
+  customerId: string,
+): Promise<{ clabe: string; raw: Record<string, unknown> } | null> {
+  const res = await etherfuseFetch(
+    `/ramp/customer/${encodeURIComponent(customerId)}/bank-accounts`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ pageSize: 30, pageNumber: 0 }),
+    },
+  );
+  const { json } = await etherfuseReadBody<{ items?: BankAccountItem[] }>(res);
+  const items: BankAccountItem[] = json?.items ?? [];
+
+  const active = items.find(
+    (x) => !x.deletedAt && x.etherfuseDepositClabe?.trim(),
+  );
+  if (!active?.etherfuseDepositClabe) return null;
+
+  return {
+    clabe: active.etherfuseDepositClabe.trim(),
+    raw: active as unknown as Record<string, unknown>,
+  };
+}
+
+async function handleGet(req: Request) {
+  try {
+    const { userId } = resolvePocUserIdFromRequest(req);
+    const record = await getUserClabe(userId);
+
+    if (!record) {
+      return NextResponse.json({ clabe: null });
+    }
+
+    return NextResponse.json({
+      clabe: record.clabe,
+      bankName: record.bank_name,
+      beneficiaryName: record.beneficiary_name,
+      reference: userId.slice(0, 8).toUpperCase(),
+      depositLimitMxn: record.deposit_limit_mxn,
+    });
+  } catch (e) {
+    return toErrorResponse(e, "deposit/clabe GET");
+  }
+}
+
+async function handlePost(req: Request) {
+  try {
+    const { userId } = resolvePocUserIdFromRequest(req);
+
+    const existing = await getUserClabe(userId);
+    if (existing) {
+      return NextResponse.json({
+        clabe: existing.clabe,
+        bankName: existing.bank_name,
+        beneficiaryName: existing.beneficiary_name,
+        reference: userId.slice(0, 8).toUpperCase(),
+        depositLimitMxn: existing.deposit_limit_mxn,
+      });
+    }
+
+    const body = await req.json().catch(() => ({})) as { wallet?: string };
+    const ctx = await resolveEtherfuseRampContext({
+      walletPublicKeyHint: body.wallet ?? null,
+    });
+
+    if (!ctx) {
+      return NextResponse.json(
+        { error: { code: "validation_error", message_es: "No se encontró contexto Etherfuse. Completa /identidad primero.", retryable: false } },
+        { status: 422 },
+      );
+    }
+
+    const found = await fetchEtherfuseDepositClabe(ctx.customerId);
+    if (!found) {
+      return NextResponse.json(
+        { error: { code: "validation_error", message_es: "Tu cuenta bancaria aún no tiene CLABE de depósito activa en Etherfuse.", retryable: true } },
+        { status: 422 },
+      );
+    }
+
+    logger.info({ userId, clabe: found.clabe }, "[deposit/clabe] provisioning CLABE");
+
+    const record = await upsertUserClabe({
+      userId,
+      clabe: found.clabe,
+      bankName: "Etherfuse",
+      beneficiaryName: "Seyf / Etherfuse",
+      rawProviderData: found.raw,
+    });
+
+    return NextResponse.json({
+      clabe: record.clabe,
+      bankName: record.bank_name,
+      beneficiaryName: record.beneficiary_name,
+      reference: userId.slice(0, 8).toUpperCase(),
+      depositLimitMxn: record.deposit_limit_mxn,
+    });
+  } catch (e) {
+    return toErrorResponse(e, "deposit/clabe POST");
+  }
+}
+
+export const GET = withLogging(handleGet as Parameters<typeof withLogging>[0], { routeName: "deposit/clabe" });
+export const POST = withLogging(handlePost as Parameters<typeof withLogging>[0], { routeName: "deposit/clabe" });

--- a/app/api/webhooks/spei/inbound/route.ts
+++ b/app/api/webhooks/spei/inbound/route.ts
@@ -1,0 +1,145 @@
+import { NextResponse } from "next/server";
+import { verifySpeiInboundWebhookSignature } from "@/lib/seyf/spei-inbound-hmac";
+import {
+  isSpeiInboundEventProcessed,
+  markSpeiInboundEventProcessed,
+  getUserIdForClabe,
+  getDepositLimitForClabe,
+  createPendingDeposit,
+} from "@/lib/seyf/spei-deposit-service";
+import { enqueueAutoDeployForDeposit } from "@/lib/seyf/spei-deposit-auto-deploy";
+import { logger } from "@/lib/observability/logger";
+import { withLogging } from "@/lib/observability/with-logging";
+
+export const runtime = "nodejs";
+
+const MIN_DEPOSIT_MXN = 500;
+
+function pickStr(obj: Record<string, unknown>, keys: string[]): string | null {
+  for (const k of keys) {
+    const v = obj[k];
+    if (typeof v === "string" && v.trim()) return v.trim();
+  }
+  return null;
+}
+
+function pickNum(obj: Record<string, unknown>, keys: string[]): number | null {
+  for (const k of keys) {
+    const v = obj[k];
+    if (typeof v === "number" && Number.isFinite(v)) return v;
+    if (typeof v === "string") {
+      const n = Number.parseFloat(v);
+      if (Number.isFinite(n)) return n;
+    }
+  }
+  return null;
+}
+
+function extractEvent(payload: unknown) {
+  const root = payload && typeof payload === "object"
+    ? (payload as Record<string, unknown>)
+    : {};
+  const data = root.data && typeof root.data === "object"
+    ? (root.data as Record<string, unknown>)
+    : root;
+
+  return {
+    eventId: pickStr(root, ["event_id", "eventId", "id"]),
+    clabe: pickStr(data, ["clabe", "destination_clabe", "destinationClabe", "beneficiary_clabe"]),
+    amountMxn: pickNum(data, ["amount", "amount_mxn", "amountMxn"]),
+    speiReference: pickStr(data, ["spei_reference", "speiReference", "reference", "tracking_key"]),
+    receivedAt: pickStr(data, ["received_at", "receivedAt", "created_at", "timestamp"]),
+  };
+}
+
+async function handlePost(req: Request) {
+  const raw = await req.text();
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const secret = process.env.SPEI_INBOUND_WEBHOOK_SECRET?.trim();
+  if (!secret) {
+    logger.error({ route: "webhooks/spei/inbound" }, "SPEI_INBOUND_WEBHOOK_SECRET not configured");
+    return NextResponse.json({ error: "Webhook not configured" }, { status: 503 });
+  }
+
+  const sig = req.headers.get("x-signature");
+  if (!verifySpeiInboundWebhookSignature(raw, sig, secret)) {
+    return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+  }
+
+  const event = extractEvent(payload);
+
+  if (!event.eventId) {
+    logger.warn({ route: "webhooks/spei/inbound" }, "Missing event_id");
+    return NextResponse.json({ ok: true });
+  }
+
+  if (await isSpeiInboundEventProcessed(event.eventId)) {
+    return NextResponse.json({ ok: true });
+  }
+
+  if (!event.clabe || event.amountMxn == null) {
+    logger.warn({ route: "webhooks/spei/inbound", eventId: event.eventId }, "Missing clabe or amount");
+    await markSpeiInboundEventProcessed(event.eventId, null);
+    return NextResponse.json({ ok: true });
+  }
+
+  const userId = await getUserIdForClabe(event.clabe);
+  if (!userId) {
+    logger.warn({ route: "webhooks/spei/inbound", clabe: event.clabe }, "CLABE not found");
+    await markSpeiInboundEventProcessed(event.eventId, null);
+    return NextResponse.json({ ok: true });
+  }
+
+  let status: "pending" | "refund_pending" = "pending";
+  let note: string | undefined;
+
+  if (event.amountMxn < MIN_DEPOSIT_MXN) {
+    status = "refund_pending";
+    note = "below_minimum";
+  } else {
+    const limit = await getDepositLimitForClabe(event.clabe);
+    if (limit !== null && event.amountMxn > limit) {
+      status = "refund_pending";
+      note = "exceeds_limit";
+    }
+  }
+
+  const deposit = await createPendingDeposit({
+    userId,
+    clabe: event.clabe,
+    amountMxn: event.amountMxn,
+    speiReference: event.speiReference,
+    receivedAt: event.receivedAt,
+    status,
+    note,
+  });
+
+  void markSpeiInboundEventProcessed(event.eventId, deposit.id);
+
+  if (status === "pending") {
+    void enqueueAutoDeployForDeposit({
+      depositId: deposit.id,
+      amountMxn: event.amountMxn,
+      userId,
+    });
+  }
+
+  logger.info(
+    { route: "webhooks/spei/inbound", eventId: event.eventId, depositId: deposit.id, status },
+    "Inbound SPEI deposit created",
+  );
+
+  return NextResponse.json({ ok: true });
+}
+
+export const POST = withLogging(handlePost as Parameters<typeof withLogging>[0], {
+  routeName: "webhooks/spei/inbound",
+  provider: "spei",
+});

--- a/lib/seyf/spei-deposit-service.ts
+++ b/lib/seyf/spei-deposit-service.ts
@@ -1,0 +1,276 @@
+/**
+ * spei-deposit-service.ts
+ *
+ * Database service layer for M03-T01: SPEI Inbound CLABE & Deposits.
+ *
+ * Responsible for:
+ *   - Persisting the user ↔ virtual-CLABE mapping (user_clabes table)
+ *   - Creating inbound SPEI deposit records (deposits table)
+ *   - Idempotency tracking (processed_spei_inbound_events table)
+ */
+
+import { query, getPool } from "@/lib/seyf/db/client";
+import { logger } from "@/lib/observability/logger";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type UserClabe = {
+  id: string;
+  user_id: string;
+  clabe: string;
+  bank_name: string;
+  beneficiary_name: string;
+  deposit_limit_mxn: number;
+  raw_provider_data: Record<string, unknown> | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type DepositRow = {
+  id: string;
+  user_id: string;
+  type: string;
+  status: string;
+  amount_mxn: string;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+};
+
+export type CreatePendingDepositParams = {
+  userId: string;
+  clabe: string;
+  amountMxn: number;
+  speiReference: string | null;
+  receivedAt: string | null;
+  /** Status override for refund paths. Defaults to 'pending'. */
+  status?: "pending" | "refund_pending";
+  /** Optional note stored in metadata (e.g. 'below_minimum', 'exceeds_limit'). */
+  note?: string;
+};
+
+// ─── CLABE Lookups ────────────────────────────────────────────────────────────
+
+/**
+ * Returns the virtual CLABE record for a user, or null if not provisioned yet.
+ */
+export async function getUserClabe(userId: string): Promise<UserClabe | null> {
+  const result = await query<{
+    id: string;
+    user_id: string;
+    clabe: string;
+    bank_name: string;
+    beneficiary_name: string;
+    deposit_limit_mxn: string;
+    raw_provider_data: Record<string, unknown> | null;
+    created_at: Date;
+    updated_at: Date;
+  }>(
+    `select id, user_id, clabe, bank_name, beneficiary_name,
+            deposit_limit_mxn::text as deposit_limit_mxn,
+            raw_provider_data, created_at, updated_at
+     from user_clabes
+     where user_id = $1`,
+    [userId],
+  );
+
+  const row = result.rows[0];
+  if (!row) return null;
+
+  return {
+    ...row,
+    deposit_limit_mxn: Number(row.deposit_limit_mxn),
+    created_at: row.created_at.toISOString(),
+    updated_at: row.updated_at.toISOString(),
+  };
+}
+
+/**
+ * Looks up the user_id that owns a given CLABE number.
+ * Used by the inbound webhook to route a transfer to the correct user.
+ */
+export async function getUserIdForClabe(clabe: string): Promise<string | null> {
+  const result = await query<{ user_id: string }>(
+    `select user_id from user_clabes where clabe = $1`,
+    [clabe],
+  );
+  return result.rows[0]?.user_id ?? null;
+}
+
+/**
+ * Returns the deposit limit (in MXN) for the user who owns a given CLABE.
+ * Returns null if the CLABE is not found.
+ */
+export async function getDepositLimitForClabe(clabe: string): Promise<number | null> {
+  const result = await query<{ deposit_limit_mxn: string }>(
+    `select deposit_limit_mxn::text as deposit_limit_mxn
+     from user_clabes where clabe = $1`,
+    [clabe],
+  );
+  const row = result.rows[0];
+  if (!row) return null;
+  return Number(row.deposit_limit_mxn);
+}
+
+// ─── CLABE Provisioning ────────────────────────────────────────────────────────
+
+/**
+ * Inserts or updates the virtual CLABE record for a user (upsert on user_id).
+ * Safe to call multiple times — returns the same CLABE if already provisioned.
+ */
+export async function upsertUserClabe(params: {
+  userId: string;
+  clabe: string;
+  bankName: string;
+  beneficiaryName: string;
+  depositLimitMxn?: number;
+  rawProviderData?: Record<string, unknown> | null;
+}): Promise<UserClabe> {
+  const {
+    userId,
+    clabe,
+    bankName,
+    beneficiaryName,
+    depositLimitMxn = 50000,
+    rawProviderData = null,
+  } = params;
+
+  const result = await query<{
+    id: string;
+    user_id: string;
+    clabe: string;
+    bank_name: string;
+    beneficiary_name: string;
+    deposit_limit_mxn: string;
+    raw_provider_data: Record<string, unknown> | null;
+    created_at: Date;
+    updated_at: Date;
+  }>(
+    `insert into user_clabes
+       (user_id, clabe, bank_name, beneficiary_name, deposit_limit_mxn, raw_provider_data)
+     values ($1, $2, $3, $4, $5, $6)
+     on conflict (user_id) do update
+       set bank_name        = excluded.bank_name,
+           beneficiary_name = excluded.beneficiary_name,
+           deposit_limit_mxn = excluded.deposit_limit_mxn,
+           raw_provider_data = excluded.raw_provider_data,
+           updated_at       = now()
+     returning id, user_id, clabe, bank_name, beneficiary_name,
+               deposit_limit_mxn::text as deposit_limit_mxn,
+               raw_provider_data, created_at, updated_at`,
+    [
+      userId,
+      clabe,
+      bankName,
+      beneficiaryName,
+      depositLimitMxn,
+      rawProviderData ? JSON.stringify(rawProviderData) : null,
+    ],
+  );
+
+  const row = result.rows[0];
+  return {
+    ...row,
+    deposit_limit_mxn: Number(row.deposit_limit_mxn),
+    created_at: row.created_at.toISOString(),
+    updated_at: row.updated_at.toISOString(),
+  };
+}
+
+// ─── Deposit Creation ─────────────────────────────────────────────────────────
+
+/**
+ * Inserts a deposit record with the given status into the `deposits` table.
+ * Returns the created row.
+ *
+ * The `deposits` table schema mirrors what `listTransactions` already expects:
+ *   id, user_id, type, status, amount_mxn, metadata, created_at, updated_at
+ */
+export async function createPendingDeposit(
+  params: CreatePendingDepositParams,
+): Promise<DepositRow> {
+  const {
+    userId,
+    clabe,
+    amountMxn,
+    speiReference,
+    receivedAt,
+    status = "pending",
+    note,
+  } = params;
+
+  const metadata: Record<string, unknown> = {
+    clabe,
+    source: "spei_inbound",
+    ...(speiReference ? { spei_reference: speiReference } : {}),
+    ...(receivedAt ? { provider_received_at: receivedAt } : {}),
+    ...(note ? { note } : {}),
+  };
+
+  // Ensure the user row exists (same pattern as withdrawal-service)
+  await query(
+    `insert into users (id) values ($1) on conflict (id) do nothing`,
+    [userId],
+  );
+
+  const result = await query<{
+    id: string;
+    user_id: string;
+    type: string;
+    status: string;
+    amount_mxn: string;
+    metadata: Record<string, unknown>;
+    created_at: Date;
+    updated_at: Date;
+  }>(
+    `insert into deposits (user_id, type, status, amount_mxn, metadata)
+     values ($1, 'deposit', $2, $3, $4::jsonb)
+     returning id, user_id, type, status,
+               amount_mxn::text as amount_mxn,
+               metadata, created_at, updated_at`,
+    [userId, status, amountMxn, JSON.stringify(metadata)],
+  );
+
+  const row = result.rows[0];
+  return {
+    ...row,
+    created_at: row.created_at.toISOString(),
+    updated_at: row.updated_at.toISOString(),
+  };
+}
+
+// ─── Idempotency ──────────────────────────────────────────────────────────────
+
+/**
+ * Returns true if this inbound SPEI event has already been processed.
+ * Prevents duplicate deposit rows on webhook re-delivery.
+ */
+export async function isSpeiInboundEventProcessed(eventId: string): Promise<boolean> {
+  const result = await query<{ event_id: string }>(
+    `select event_id from processed_spei_inbound_events where event_id = $1`,
+    [eventId],
+  );
+  return result.rows.length > 0;
+}
+
+/**
+ * Marks an inbound SPEI event as processed (idempotent insert — on conflict do nothing).
+ */
+export async function markSpeiInboundEventProcessed(
+  eventId: string,
+  depositId: string | null,
+): Promise<void> {
+  try {
+    await query(
+      `insert into processed_spei_inbound_events (event_id, deposit_id)
+       values ($1, $2)
+       on conflict (event_id) do nothing`,
+      [eventId, depositId],
+    );
+  } catch (e) {
+    logger.error(
+      { eventId, depositId, error: e instanceof Error ? e.message : String(e) },
+      "[spei-deposit-service] Failed to mark inbound SPEI event as processed",
+    );
+  }
+}

--- a/lib/seyf/spei-inbound-hmac.ts
+++ b/lib/seyf/spei-inbound-hmac.ts
@@ -1,0 +1,34 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+/**
+ * Verifies the HMAC-SHA256 signature on an inbound SPEI webhook.
+ *
+ * The provider signs over the **raw request body bytes** and sends the result
+ * in the `X-Signature` header as `sha256=<hex>`.
+ *
+ * Secret is the plain hex string stored in `SPEI_INBOUND_WEBHOOK_SECRET`
+ * (not base64-encoded, unlike the Etherfuse webhook secret).
+ *
+ * @param rawBody         Raw request body buffer (before JSON.parse)
+ * @param signatureHeader Value of the `x-signature` request header
+ * @param secret          Value of `SPEI_INBOUND_WEBHOOK_SECRET` env var
+ */
+export function verifySpeiInboundWebhookSignature(
+  rawBody: Buffer | string,
+  signatureHeader: string | null | undefined,
+  secret: string,
+): boolean {
+  if (!signatureHeader || !secret) return false;
+
+  const body = typeof rawBody === "string" ? Buffer.from(rawBody, "utf8") : rawBody;
+  const hmac = createHmac("sha256", secret).update(body).digest("hex");
+  const expected = `sha256=${hmac}`;
+
+  if (expected.length !== signatureHeader.length) return false;
+
+  try {
+    return timingSafeEqual(Buffer.from(expected), Buffer.from(signatureHeader));
+  } catch {
+    return false;
+  }
+}

--- a/scripts/migrations/0006_spei_inbound.sql
+++ b/scripts/migrations/0006_spei_inbound.sql
@@ -1,0 +1,34 @@
+-- Migration: 0006_spei_inbound.sql
+-- M03-T01: SPEI Inbound — Virtual CLABE Generation & Webhook
+--
+-- Creates:
+--   user_clabes                  — static virtual CLABE per user (MVP: one per user)
+--   processed_spei_inbound_events — idempotency table for inbound SPEI webhooks
+
+-- ─── user_clabes ─────────────────────────────────────────────────────────────
+create table if not exists user_clabes (
+  id                uuid        primary key default gen_random_uuid(),
+  user_id           text        not null unique,
+  clabe             char(18)    not null unique,
+  bank_name         text        not null default 'Etherfuse',
+  beneficiary_name  text        not null,
+  -- Maximum total deposit the user is allowed (default: 50,000 MXN CNBV standard)
+  deposit_limit_mxn numeric(14, 2) not null default 50000,
+  -- Raw payload from the CLABE provider (Etherfuse bank-account object)
+  raw_provider_data jsonb,
+  created_at        timestamptz not null default now(),
+  updated_at        timestamptz not null default now()
+);
+
+comment on table user_clabes is
+  'Maps one static virtual CLABE to each Seyf user for MVP inbound SPEI transfers.';
+
+-- ─── processed_spei_inbound_events ───────────────────────────────────────────
+create table if not exists processed_spei_inbound_events (
+  event_id    text      primary key,
+  deposit_id  uuid,                        -- null if we could not create a deposit (refund path)
+  created_at  timestamptz not null default now()
+);
+
+comment on table processed_spei_inbound_events is
+  'Idempotency log for POST /api/webhooks/spei/inbound — prevents duplicate deposit records on re-delivery.';


### PR DESCRIPTION
- Close #23 

# feat(M03-T01): SPEI Inbound — Virtual CLABE Generation & Webhook

## Summary

Implements full SPEI inbound deposit flow per PRD §2.2 US-03 and US-04. Users now see a permanent virtual CLABE on `/depositar`, can copy each field with one tap, and receive a real-time "Depósito recibido" banner when a transfer arrives.

---

## What Changed

### Database
- **`scripts/migrations/0006_spei_inbound.sql`** — Two new tables:
  - `user_clabes` — stores one static virtual CLABE per user (CNBV default limit 50,000 MXN)
  - `processed_spei_inbound_events` — idempotency log keyed by `event_id`; prevents duplicate deposit rows on webhook re-delivery

### Backend

| File | Description |
|---|---|
| `lib/seyf/spei-inbound-hmac.ts` | HMAC-SHA256 verifier over raw request body bytes (timing-safe) |
| `lib/seyf/spei-deposit-service.ts` | DB service: `getUserClabe`, `getUserIdForClabe`, `upsertUserClabe`, `createPendingDeposit`, `isSpeiInboundEventProcessed`, `markSpeiInboundEventProcessed` |
| `app/api/deposit/clabe/route.ts` | `GET` — returns existing CLABE or `{ clabe: null }`. `POST` — provisions from Etherfuse `etherfuseDepositClabe`, persists to `user_clabes`, idempotent |
| `app/api/webhooks/spei/inbound/route.ts` | Inbound SPEI webhook — HMAC verify → idempotency check → amount validation → insert deposit → fire-and-forget auto-deploy |

### Frontend

| File | Description |
|---|---|
| `app/(app)/depositar/page.tsx` | Was `redirect('/anadir')`. Now a server component — preloads CLABE from DB via cookie, SSR-renders client |
| `app/(app)/depositar/depositar-client.tsx` | CLABE card with per-field copy buttons, "Activar CLABE" provision flow, 4s polling loop, "Depósito recibido" banner |

### Config
- `.env.example` — Added `SPEI_INBOUND_WEBHOOK_SECRET` (commented, with generation instructions)

---

## Acceptance Criteria

| Criterion | Status |
|---|---|
| `POST /api/deposit/clabe` provisions a unique CLABE per user if one doesn't exist | ✅ |
| `GET /api/deposit/clabe` returns CLABE, bank name, beneficiary, reference | ✅ |
| `/depositar` shows CLABE with one-tap copy per field | ✅ |
| Webhook at `POST /api/webhooks/spei/inbound` validated with HMAC-SHA256 | ✅ |
| Webhook creates a deposit record with `status = pending` and raw amount | ✅ |
| Deposits < 500 MXN → `status = refund_pending`, note `below_minimum` | ✅ |
| Deposits > `deposit_limit_mxn` → `status = refund_pending`, note `exceeds_limit` | ✅ |
| Webhook idempotent — re-delivered events do not create duplicate deposits | ✅ |
| `/depositar` shows "Depósito recibido" banner on new deposit (polling) | ✅ |

---

## How It Works

```
User opens /depositar
  → Server reads seyf_poc_user_id cookie
  → Queries user_clabes table (preloads for SSR)
  → If no CLABE: shows "Activar CLABE" button
      → POST /api/deposit/clabe
      → Resolves Etherfuse context (cookie / Redis / org lookup)
      → Reads etherfuseDepositClabe from Etherfuse /ramp/bank-accounts
      → Persists to user_clabes (upsert — safe to call multiple times)
  → CLABE card renders with copy buttons for each field
  → Client polls GET /api/deposit/status every 4s
      → On new pending deposit → shows green "Depósito recibido" banner (8s auto-dismiss)

SPEI provider sends transfer
  → POST /api/webhooks/spei/inbound
  → Verify HMAC-SHA256 over raw body (timing-safe)
  → Check processed_spei_inbound_events (idempotency)
  → Look up user_id by CLABE
  → Validate amount: < 500 MXN or > deposit_limit_mxn → refund_pending
  → INSERT into deposits (status = pending | refund_pending)
  → Mark event processed
  → Fire-and-forget: enqueueAutoDeployForDeposit
  → Return { ok: true } — always 200, always within 5s
```

---

## Deployment Checklist

- [ ] Run `scripts/migrations/0006_spei_inbound.sql` against Postgres
- [ ] Set `SPEI_INBOUND_WEBHOOK_SECRET` in secrets manager (`openssl rand -hex 32`)
- [ ] Register inbound webhook URL with SPEI provider: `POST https://<domain>/api/webhooks/spei/inbound`
- [ ] Verify `DATABASE_URL` is set (CLABE provisioning and deposit writes require Postgres)

---

## Testing

- **Type check:** 0 errors in all M03-T01 files (`tsc --noEmit`)
- **Idempotency:** Send the same webhook payload twice → single row in `deposits`
- **Below minimum:** Send `amount = 499` → `status = refund_pending`, `note = below_minimum`
- **Exceeds limit:** Send `amount > deposit_limit_mxn` → `status = refund_pending`, `note = exceeds_limit`
- **Invalid HMAC:** Expect `401`
- **Missing secret env var:** Expect `503`

---

## References

- PRD §2.2 US-03, US-04
- Follows patterns from `app/api/webhooks/spei/outbound/route.ts` (HMAC, idempotency, fire-and-forget)
- CLABE source: Etherfuse `etherfuseDepositClabe` field from `GET /ramp/bank-accounts` (same as existing `/activate-deposit-clabe` flow)
